### PR TITLE
-add All external libraries with dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+macro(SUBDIRLIST result curdir)
+  FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  SET(dirlist "")
+  FOREACH(child ${children})
+    IF(IS_DIRECTORY ${curdir}/${child})
+        SET(dirlist ${dirlist} ${child})
+    ENDIF()
+  ENDFOREACH()
+  SET(${result} ${dirlist})
+endmacro()
+
+SUBDIRLIST(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR}/modules)
+
+FOREACH(subdir ${SUBDIRS})
+        ADD_SUBDIRECTORY(${CMAKE_CURRENT_SOURCE_DIR}/modules/${subdir})
+ENDFOREACH()

--- a/library.json
+++ b/library.json
@@ -1,0 +1,19 @@
+{
+    "name":"Sensor",
+    "build": {
+        "srcDir": "modules",
+        "flags": [
+            "-I modules/i2c",
+            "-I modules/hal_sensors/sensor_base",
+            "-I modules/hal_sensors/sensor_compression",
+            "-I modules/hal_sensors/sensor_differentialpressure",
+            "-I modules/hal_sensors/sensor_fingerposition"
+        ]
+    },
+    "dependencies":
+    [
+        {
+            "name":"googletest"
+        }
+    ]
+}

--- a/modules/hal_sensors/CMakeLists.txt
+++ b/modules/hal_sensors/CMakeLists.txt
@@ -1,0 +1,16 @@
+macro(SUBDIRLIST result curdir)
+  FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
+  SET(dirlist "")
+  FOREACH(child ${children})
+    IF(IS_DIRECTORY ${curdir}/${child})
+        SET(dirlist ${dirlist} ${child})
+    ENDIF()
+  ENDFOREACH()
+  SET(${result} ${dirlist})
+endmacro()
+
+SUBDIRLIST(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
+
+FOREACH(subdir ${SUBDIRS})
+        ADD_SUBDIRECTORY(${subdir})
+ENDFOREACH()

--- a/modules/hal_sensors/sensor_base/CMakeLists.txt
+++ b/modules/hal_sensors/sensor_base/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB HEADER_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+file(GLOB SOURCE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Make an automatic library - will be static or dynamic based on user setting
+add_library(hal_sensor ${HEADER_LIST})
+
+# We need this directory, and users of our library will need it too
+target_include_directories(hal_sensor PUBLIC .)
+
+target_link_libraries(hal_sensor PUBLIC i2c)

--- a/modules/hal_sensors/sensor_base/sensor_base.hpp
+++ b/modules/hal_sensors/sensor_base/sensor_base.hpp
@@ -1,0 +1,21 @@
+#ifndef SENSOR_BASE_H
+#define SENSOR_BASE_H
+
+#include <i2c_helper.hpp>
+
+typedef struct {
+  uint16_t buffer[8];
+  uint8_t numOfBytes;
+} SensorData;
+
+class UniversalSensor {
+ public:
+  explicit UniversalSensor(i2c_peripheral_t i2c_peripheral) {}
+  virtual void Initialize() = 0;
+  virtual SensorData GetSensorData() = 0;
+  virtual void Uninitialize() = 0;
+ private:
+  i2c_peripheral_t peripheral_;
+};
+
+#endif  // SENSOR_BASE_H

--- a/modules/hal_sensors/sensor_base/sensor_helper.hpp
+++ b/modules/hal_sensors/sensor_base/sensor_helper.hpp
@@ -1,0 +1,9 @@
+#ifndef SENSOR_HELPER_HPP
+#define SENSOR_HELPER_HPP
+
+#include <sensor_base.hpp>
+#include <sensor_compression.hpp>
+#include <sensor_differentialpressure.hpp>
+#include <sensor_fingerposition.hpp>
+
+#endif

--- a/modules/hal_sensors/sensor_compression/CMakeLists.txt
+++ b/modules/hal_sensors/sensor_compression/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB HEADER_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+file(GLOB SOURCE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Make an automatic library - will be static or dynamic based on user setting
+add_library(hal_compression ${SOURCE_LIST} ${HEADER_LIST})
+
+# We need this directory, and users of our library will need it too
+target_include_directories(hal_compression PUBLIC .)
+
+target_link_libraries(hal_compression PUBLIC i2c)
+target_link_libraries(hal_compression PUBLIC hal_sensor)

--- a/modules/hal_sensors/sensor_compression/drivers/VL6180x.cpp
+++ b/modules/hal_sensors/sensor_compression/drivers/VL6180x.cpp
@@ -1,0 +1,213 @@
+/******************************************************************************
+ * SparkFun_VL6180x.cpp
+ * Library for VL6180x time of flight range finder.
+ * Casey Kuhns @ SparkFun Electronics
+ * 10/29/2014
+ * https://github.com/sparkfun/SparkFun_ToF_Range_Finder-VL6180_Arduino_Library
+ *
+ * The VL6180x by ST micro is a time of flight range finder that
+ * uses pulsed IR light to determine distances from object at close
+ * range.  The average range of a sensor is between 0-200mm
+ *
+ * In this file are the functions in the VL6180x class
+ *
+ * Resources:
+ * This library uses the Arduino _wire->h to complete I2C transactions.
+ *
+ * Development environment specifics:
+ * 	IDE: Arduino 1.0.5
+ * 	Hardware Platform: Arduino Pro 3.3V/8MHz
+ * 	VL6180x Breakout Version: 1.0
+ * **Updated for Arduino 1.6.4 5/2015**
+ *
+ * This code is beerware. If you see me (or any other SparkFun employee) at the
+ * local pub, and you've found our code helpful, please buy us a round!
+ *
+ * Distributed as-is; no warranty is given.
+ ******************************************************************************/
+
+#include "VL6180x.hpp"
+#ifdef __arm__
+#include "Arduino.h"
+#define sleep(ms) delay(ms)
+#else
+#define sleep(ms) usleep(1000*ms)
+#endif
+
+
+RobotPatient_VL6180x::RobotPatient_VL6180x(I2CDriver* i2c_handle)
+// Initialize the Library
+{
+  _i2c_handle = i2c_handle;
+}
+uint8_t RobotPatient_VL6180x::init(void)
+{
+  uint8_t data; // for temp data storage
+
+  data = _i2c_handle->read_reg(VL6180X_SYSTEM_FRESH_OUT_OF_RESET);
+  if (data != 1)
+    return VL6180x_FAILURE_RESET;
+
+  // Required by datasheet
+  // http://www.st.com/st-web-ui/static/active/en/resource/technical/document/application_note/DM00122600.pdf
+  _i2c_handle->write_reg(0x0207, 0x01);
+  _i2c_handle->write_reg(0x0208, 0x01);
+  _i2c_handle->write_reg(0x0096, 0x00);
+  _i2c_handle->write_reg(0x0097, 0xfd);
+  _i2c_handle->write_reg(0x00e3, 0x00);
+  _i2c_handle->write_reg(0x00e4, 0x04);
+  _i2c_handle->write_reg(0x00e5, 0x02);
+  _i2c_handle->write_reg(0x00e6, 0x01);
+  _i2c_handle->write_reg(0x00e7, 0x03);
+  _i2c_handle->write_reg(0x00f5, 0x02);
+  _i2c_handle->write_reg(0x00d9, 0x05);
+  _i2c_handle->write_reg(0x00db, 0xce);
+  _i2c_handle->write_reg(0x00dc, 0x03);
+  _i2c_handle->write_reg(0x00dd, 0xf8);
+  _i2c_handle->write_reg(0x009f, 0x00);
+  _i2c_handle->write_reg(0x00a3, 0x3c);
+  _i2c_handle->write_reg(0x00b7, 0x00);
+  _i2c_handle->write_reg(0x00bb, 0x3c);
+  _i2c_handle->write_reg(0x00b2, 0x09);
+  _i2c_handle->write_reg(0x00ca, 0x09);
+  _i2c_handle->write_reg(0x0198, 0x01);
+  _i2c_handle->write_reg(0x01b0, 0x17);
+  _i2c_handle->write_reg(0x01ad, 0x00);
+  _i2c_handle->write_reg(0x00ff, 0x05);
+  _i2c_handle->write_reg(0x0100, 0x05);
+  _i2c_handle->write_reg(0x0199, 0x05);
+  _i2c_handle->write_reg(0x01a6, 0x1b);
+  _i2c_handle->write_reg(0x01ac, 0x3e);
+  _i2c_handle->write_reg(0x01a7, 0x1f);
+  _i2c_handle->write_reg(0x0030, 0x00);
+
+  return 0;
+}
+
+void RobotPatient_VL6180x::VL6180xDefautSettings(void)
+{
+  // Recommended settings from datasheet
+  // http://www.st.com/st-web-ui/static/active/en/resource/technical/document/application_note/DM00122600.pdf
+
+  // Enable Interrupts on Conversion Complete (any source)
+  _i2c_handle->write_reg(VL6180X_SYSTEM_INTERRUPT_CONFIG_GPIO, (4 << 3) | (4)); // Set GPIO1 high when sample complete
+
+  _i2c_handle->write_reg(VL6180X_SYSTEM_MODE_GPIO1, 0x10);               // Set GPIO1 high when sample complete
+  _i2c_handle->write_reg(VL6180X_READOUT_AVERAGING_SAMPLE_PERIOD, 0x30); // Set Avg sample period
+  _i2c_handle->write_reg(VL6180X_SYSALS_ANALOGUE_GAIN, 0x46);            // Set the ALS gain
+  _i2c_handle->write_reg(VL6180X_SYSRANGE_VHV_REPEAT_RATE, 0xFF);        // Set auto calibration period (Max = 255)/(OFF = 0)
+  _i2c_handle->write_reg(VL6180X_SYSALS_INTEGRATION_PERIOD, 0x63);       // Set ALS integration time to 100ms
+  _i2c_handle->write_reg(VL6180X_SYSRANGE_VHV_RECALIBRATE, 0x01);        // perform a single temperature calibration
+  // Optional settings from datasheet
+  // http://www.st.com/st-web-ui/static/active/en/resource/technical/document/application_note/DM00122600.pdf
+  _i2c_handle->write_reg(VL6180X_SYSRANGE_INTERMEASUREMENT_PERIOD, 0x09); // Set default ranging inter-measurement period to 100ms
+  _i2c_handle->write_reg(VL6180X_SYSALS_INTERMEASUREMENT_PERIOD, 0x0A);   // Set default ALS inter-measurement period to 100ms
+  _i2c_handle->write_reg(VL6180X_SYSTEM_INTERRUPT_CONFIG_GPIO, 0x24);     // Configures interrupt on ‘New Sample Ready threshold event’
+  // Additional settings defaults from community
+  _i2c_handle->write_reg(VL6180X_SYSRANGE_MAX_CONVERGENCE_TIME, 0x32);
+  _i2c_handle->write_reg(VL6180X_SYSRANGE_RANGE_CHECK_ENABLES, 0x10 | 0x01);
+  _i2c_handle->write_reg16(VL6180X_SYSRANGE_EARLY_CONVERGENCE_ESTIMATE, 0x7B);
+  _i2c_handle->write_reg16(VL6180X_SYSALS_INTEGRATION_PERIOD, 0x64);
+
+  _i2c_handle->write_reg(VL6180X_READOUT_AVERAGING_SAMPLE_PERIOD, 0x30);
+  _i2c_handle->write_reg(VL6180X_SYSALS_ANALOGUE_GAIN, 0x40);
+  _i2c_handle->write_reg(VL6180X_FIRMWARE_RESULT_SCALER, 0x01);
+}
+void RobotPatient_VL6180x::getIdentification(struct VL6180xIdentification *temp)
+{
+
+  temp->idModel = _i2c_handle->read_reg(VL6180X_IDENTIFICATION_MODEL_ID);
+  temp->idModelRevMajor = _i2c_handle->read_reg(VL6180X_IDENTIFICATION_MODEL_REV_MAJOR);
+  temp->idModelRevMinor = _i2c_handle->read_reg(VL6180X_IDENTIFICATION_MODEL_REV_MINOR);
+  temp->idModuleRevMajor = _i2c_handle->read_reg(VL6180X_IDENTIFICATION_MODULE_REV_MAJOR);
+  temp->idModuleRevMinor = _i2c_handle->read_reg(VL6180X_IDENTIFICATION_MODULE_REV_MINOR);
+
+  temp->idDate = _i2c_handle->read_reg16(VL6180X_IDENTIFICATION_DATE);
+  temp->idTime = _i2c_handle->read_reg16(VL6180X_IDENTIFICATION_TIME);
+}
+
+uint8_t RobotPatient_VL6180x::changeAddress(uint8_t old_address, uint8_t new_address)
+{
+
+  // NOTICE:  IT APPEARS THAT CHANGING THE ADDRESS IS NOT STORED IN NON-VOLATILE MEMORY
+  //  POWER CYCLING THE DEVICE REVERTS ADDRESS BACK TO 0X29
+
+  if (old_address == new_address)
+    return old_address;
+  if (new_address > 127)
+    return old_address;
+
+  _i2c_handle->write_reg(VL6180X_I2C_SLAVE_DEVICE_ADDRESS, new_address);
+  _i2caddress = new_address;
+  return _i2c_handle->read_reg(VL6180X_I2C_SLAVE_DEVICE_ADDRESS);
+}
+
+uint8_t RobotPatient_VL6180x::getDistance()
+{
+  _i2c_handle->write_reg(VL6180X_SYSRANGE_START, 0x01); // Start Single shot mode
+  sleep(10);
+  _i2c_handle->write_reg(VL6180X_SYSTEM_INTERRUPT_CLEAR, 0x07);
+  return _i2c_handle->read_reg(VL6180X_RESULT_RANGE_VAL);
+  //	return distance;
+}
+
+float RobotPatient_VL6180x::getAmbientLight(vl6180x_als_gain VL6180X_ALS_GAIN)
+{
+  // First load in Gain we are using, do it everytime incase someone changes it on us.
+  // Note: Upper nibble shoudl be set to 0x4 i.e. for ALS gain of 1.0 write 0x46
+  _i2c_handle->write_reg(VL6180X_SYSALS_ANALOGUE_GAIN, (0x40 | VL6180X_ALS_GAIN)); // Set the ALS gain
+
+  // Start ALS Measurement
+  _i2c_handle->write_reg(VL6180X_SYSALS_START, 0x01);
+
+  sleep(100); // give it time...
+
+  _i2c_handle->write_reg(VL6180X_SYSTEM_INTERRUPT_CLEAR, 0x07);
+
+  // Retrieve the Raw ALS value from the sensoe
+  unsigned int alsRaw = _i2c_handle->read_reg16(VL6180X_RESULT_ALS_VAL);
+
+  // Get Integration Period for calculation, we do this everytime incase someone changes it on us.
+  unsigned int alsIntegrationPeriodRaw = _i2c_handle->read_reg16(VL6180X_SYSALS_INTEGRATION_PERIOD);
+
+  float alsIntegrationPeriod = 100.0 / alsIntegrationPeriodRaw;
+
+  // Calculate actual LUX from Appnotes
+
+  float alsGain = 0.0;
+
+  switch (VL6180X_ALS_GAIN)
+  {
+  case GAIN_20:
+    alsGain = 20.0;
+    break;
+  case GAIN_10:
+    alsGain = 10.32;
+    break;
+  case GAIN_5:
+    alsGain = 5.21;
+    break;
+  case GAIN_2_5:
+    alsGain = 2.60;
+    break;
+  case GAIN_1_67:
+    alsGain = 1.72;
+    break;
+  case GAIN_1_25:
+    alsGain = 1.28;
+    break;
+  case GAIN_1:
+    alsGain = 1.01;
+    break;
+  case GAIN_40:
+    alsGain = 40.0;
+    break;
+  }
+
+  // Calculate LUX from formula in AppNotes
+
+  float alsCalculated = (float)0.32 * ((float)alsRaw / alsGain) * alsIntegrationPeriod;
+
+  return alsCalculated;
+}
+

--- a/modules/hal_sensors/sensor_compression/drivers/VL6180x.hpp
+++ b/modules/hal_sensors/sensor_compression/drivers/VL6180x.hpp
@@ -1,0 +1,179 @@
+/******************************************************************************
+ * SparkFun_VL6180X.h
+ * Library for VL6180x time of flight range finder.
+ * Casey Kuhns @ SparkFun Electronics
+ * 10/29/2014
+ * https://github.com/sparkfun/SparkFun_ToF_Range_Finder-VL6180_Arduino_Library
+ *
+ * The VL6180x by ST micro is a time of flight range finder that
+ * uses pulsed IR light to determine distances from object at close
+ * range.  The average range of a sensor is between 0-200mm
+ *
+ * In this file are the function prototypes in the VL6180x class
+ *
+ * Resources:
+ * This library uses the Arduino Wire.h to complete I2C transactions.
+ *
+ * Development environment specifics:
+ * 	IDE: Arduino 1.0.5
+ * 	Hardware Platform: Arduino Pro 3.3V/8MHz
+ * 	VL6180x Breakout Version: 1.0
+
+ **Updated for Arduino 1.6.4 5/2015**
+ *
+ * Some settings and initial values come from code written by Kris Winer
+ * VL6180X_t3 Basic Example Code
+ * by: Kris Winer
+ * date: September 1, 2014
+ * license: Beerware - Use this code however you'd like. If you
+ * find it useful you can buy me a beer some time.
+ *
+ * This code is beerware. If you see me (or any other SparkFun employee) at the
+ * local pub, and you've found our code helpful, please buy us a round!
+ *
+ * Distributed as-is; no warranty is given.
+
+ *
+ * J.A. Korten 17 jan 2022
+ * Changes to work with SERCOM
+ * Should work with RobotPatient VL6180 sensor board
+ *
+ ******************************************************************************/
+
+#ifndef RobotPatient_VL6180X_H
+#define RobotPatient_VL6180X_H
+
+#include <i2c_helper.hpp>
+
+#define VL6180x_FAILURE_RESET -1
+
+#define VL6180X_IDENTIFICATION_MODEL_ID 0x0000
+#define VL6180X_IDENTIFICATION_MODEL_REV_MAJOR 0x0001
+#define VL6180X_IDENTIFICATION_MODEL_REV_MINOR 0x0002
+#define VL6180X_IDENTIFICATION_MODULE_REV_MAJOR 0x0003
+#define VL6180X_IDENTIFICATION_MODULE_REV_MINOR 0x0004
+#define VL6180X_IDENTIFICATION_DATE 0x0006 // 16bit value
+#define VL6180X_IDENTIFICATION_TIME 0x0008 // 16bit value
+
+#define VL6180X_SYSTEM_MODE_GPIO0 0x0010
+#define VL6180X_SYSTEM_MODE_GPIO1 0x0011
+#define VL6180X_SYSTEM_HISTORY_CTRL 0x0012
+#define VL6180X_SYSTEM_INTERRUPT_CONFIG_GPIO 0x0014
+#define VL6180X_SYSTEM_INTERRUPT_CLEAR 0x0015
+#define VL6180X_SYSTEM_FRESH_OUT_OF_RESET 0x0016
+#define VL6180X_SYSTEM_GROUPED_PARAMETER_HOLD 0x0017
+
+#define VL6180X_SYSRANGE_START 0x0018
+#define VL6180X_SYSRANGE_THRESH_HIGH 0x0019
+#define VL6180X_SYSRANGE_THRESH_LOW 0x001A
+#define VL6180X_SYSRANGE_INTERMEASUREMENT_PERIOD 0x001B
+#define VL6180X_SYSRANGE_MAX_CONVERGENCE_TIME 0x001C
+#define VL6180X_SYSRANGE_CROSSTALK_COMPENSATION_RATE 0x001E
+#define VL6180X_SYSRANGE_CROSSTALK_VALID_HEIGHT 0x0021
+#define VL6180X_SYSRANGE_EARLY_CONVERGENCE_ESTIMATE 0x0022
+#define VL6180X_SYSRANGE_PART_TO_PART_RANGE_OFFSET 0x0024
+#define VL6180X_SYSRANGE_RANGE_IGNORE_VALID_HEIGHT 0x0025
+#define VL6180X_SYSRANGE_RANGE_IGNORE_THRESHOLD 0x0026
+#define VL6180X_SYSRANGE_MAX_AMBIENT_LEVEL_MULT 0x002C
+#define VL6180X_SYSRANGE_RANGE_CHECK_ENABLES 0x002D
+#define VL6180X_SYSRANGE_VHV_RECALIBRATE 0x002E
+#define VL6180X_SYSRANGE_VHV_REPEAT_RATE 0x0031
+
+#define VL6180X_SYSALS_START 0x0038
+#define VL6180X_SYSALS_THRESH_HIGH 0x003A
+#define VL6180X_SYSALS_THRESH_LOW 0x003C
+#define VL6180X_SYSALS_INTERMEASUREMENT_PERIOD 0x003E
+#define VL6180X_SYSALS_ANALOGUE_GAIN 0x003F
+#define VL6180X_SYSALS_INTEGRATION_PERIOD 0x0040
+
+#define VL6180X_RESULT_RANGE_STATUS 0x004D
+#define VL6180X_RESULT_ALS_STATUS 0x004E
+#define VL6180X_RESULT_INTERRUPT_STATUS_GPIO 0x004F
+#define VL6180X_RESULT_ALS_VAL 0x0050
+#define VL6180X_RESULT_HISTORY_BUFFER 0x0052
+#define VL6180X_RESULT_RANGE_VAL 0x0062
+#define VL6180X_RESULT_RANGE_RAW 0x0064
+#define VL6180X_RESULT_RANGE_RETURN_RATE 0x0066
+#define VL6180X_RESULT_RANGE_REFERENCE_RATE 0x0068
+#define VL6180X_RESULT_RANGE_RETURN_SIGNAL_COUNT 0x006C
+#define VL6180X_RESULT_RANGE_REFERENCE_SIGNAL_COUNT 0x0070
+#define VL6180X_RESULT_RANGE_RETURN_AMB_COUNT 0x0074
+#define VL6180X_RESULT_RANGE_REFERENCE_AMB_COUNT 0x0078
+#define VL6180X_RESULT_RANGE_RETURN_CONV_TIME 0x007C
+#define VL6180X_RESULT_RANGE_REFERENCE_CONV_TIME 0x0080
+
+#define VL6180X_READOUT_AVERAGING_SAMPLE_PERIOD 0x010A
+#define VL6180X_FIRMWARE_BOOTUP 0x0119
+#define VL6180X_FIRMWARE_RESULT_SCALER 0x0120
+#define VL6180X_I2C_SLAVE_DEVICE_ADDRESS 0x0212
+#define VL6180X_INTERLEAVED_MODE_ENABLE 0x02A3
+
+enum vl6180x_als_gain
+{ // Data sheet shows gain values as binary list
+
+  GAIN_20 = 0, // Actual ALS Gain of 20
+  GAIN_10,     // Actual ALS Gain of 10.32
+  GAIN_5,      // Actual ALS Gain of 5.21
+  GAIN_2_5,    // Actual ALS Gain of 2.60
+  GAIN_1_67,   // Actual ALS Gain of 1.72
+  GAIN_1_25,   // Actual ALS Gain of 1.28
+  GAIN_1,      // Actual ALS Gain of 1.01
+  GAIN_40,     // Actual ALS Gain of 40
+
+};
+
+struct VL6180xIdentification
+{
+  uint8_t idModel;
+  uint8_t idModelRevMajor;
+  uint8_t idModelRevMinor;
+  uint8_t idModuleRevMajor;
+  uint8_t idModuleRevMinor;
+  uint16_t idDate;
+  uint16_t idTime;
+};
+
+class RobotPatient_VL6180x
+{
+public:
+  // Initalize library with default address
+  RobotPatient_VL6180x(I2CDriver* i2c_handle);
+  // Send manditory settings as stated in ST datasheet.
+  //  http://www.st.com/st-web-ui/static/active/en/resource/technical/document/application_note/DM00122600.pdf (Section 1.3)
+  uint8_t init(void);
+  // Use default settings from ST data sheet section 9.
+  // http://www.st.com/st-web-ui/static/active/en/resource/technical/document/application_note/DM00122600.pdf
+  void VL6180xDefautSettings(void);
+
+  // Get Range distance in (mm)
+  uint8_t getDistance();
+  // Get ALS level in Lux
+  float getAmbientLight(vl6180x_als_gain VL6180X_ALS_GAIN);
+
+  // Load structure provided by the user with identification info
+  // Structure example:
+  //  struct VL6180xIdentification
+  //   {
+  //    uint8_t idModel;
+  //    uint8_t idModelRevMajor;
+  //    uint8_t idModelRevMinor;
+  //    uint8_t idModuleRevMajor;
+  //    uint8_t idModuleRevMinor;
+  //    uint16_t idDate;
+  //    uint16_t idTime;
+  //    };
+  void getIdentification(struct VL6180xIdentification *temp);
+
+  // Change the default address of the device to allow multiple
+  // sensors on the bus.  Can use up to 127 sensors. New address
+  // is saved in non-volatile device memory.
+  uint8_t changeAddress(uint8_t old_address, uint8_t new_address);
+
+private:
+  // Store address given when the class is initialized.
+  // This value can be changed by the changeAddress() function
+  int _i2caddress;
+  I2CDriver* _i2c_handle;
+};
+
+#endif

--- a/modules/hal_sensors/sensor_compression/sensor_compression.cpp
+++ b/modules/hal_sensors/sensor_compression/sensor_compression.cpp
@@ -1,0 +1,16 @@
+#include <sensor_compression.hpp>
+
+void CompressionSensor::Initialize() {
+  Tof_->init();
+  Tof_->VL6180xDefautSettings();
+}
+
+SensorData CompressionSensor::GetSensorData() {
+  uint8_t distance = Tof_->getDistance();
+  sensor_data_.numOfBytes = 1;
+  sensor_data_.buffer[0] = distance;
+  return sensor_data_;
+}
+
+void CompressionSensor::Uninitialize() {}
+

--- a/modules/hal_sensors/sensor_compression/sensor_compression.hpp
+++ b/modules/hal_sensors/sensor_compression/sensor_compression.hpp
@@ -1,0 +1,26 @@
+#ifndef SENSOR_COMPRESSION_HPP
+#define SENSOR_COMPRESSION_HPP
+
+#include "sensor_base.hpp"
+#include "drivers/VL6180x.hpp"
+
+class CompressionSensor : public UniversalSensor {
+ public:
+  explicit CompressionSensor(i2c_peripheral_t i2c_peripheral)
+      : UniversalSensor(i2c_peripheral) {
+    i2c_handle_ = new I2CDriver(i2c_peripheral, i2c_speed_400KHz, kSensorI2CAddress_);
+    Tof_ = new RobotPatient_VL6180x(i2c_handle_);
+  }
+  void Initialize() override;
+  SensorData GetSensorData() override;
+  void Uninitialize() override;
+  ~CompressionSensor() {
+    Uninitialize();
+  }
+ private:
+  const uint8_t kSensorI2CAddress_ = 0x29;
+  SensorData sensor_data_{};
+  I2CDriver *i2c_handle_;
+  RobotPatient_VL6180x *Tof_;
+};
+#endif  // SENSOR_COMPRESSION_HPP

--- a/modules/hal_sensors/sensor_differentialpressure/CMakeLists.txt
+++ b/modules/hal_sensors/sensor_differentialpressure/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB HEADER_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+file(GLOB SOURCE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Make an automatic library - will be static or dynamic based on user setting
+add_library(hal_differentialpressure ${SOURCE_LIST} ${HEADER_LIST})
+
+# We need this directory, and users of our library will need it too
+target_include_directories(hal_differentialpressure PUBLIC .)
+
+target_link_libraries(hal_differentialpressure PUBLIC i2c)
+target_link_libraries(hal_differentialpressure PUBLIC hal_sensor)

--- a/modules/hal_sensors/sensor_differentialpressure/drivers/SDP810.cpp
+++ b/modules/hal_sensors/sensor_differentialpressure/drivers/SDP810.cpp
@@ -1,0 +1,61 @@
+/**
+ * @file SDP810.cpp
+ * @author Thomas IJsseldijk (fhm.ijsseldijk@student.han.nl)
+ * @brief 
+ * @version 0.1
+ * @date 07-10-2022
+ * 
+ * @copyright Copyright (c) 2022
+ * 
+ */
+
+
+#include "SDP810.hpp"
+
+
+/**
+ * @brief Construct a new SDP810::SDP810 object
+ * 
+ */
+SDP810::SDP810(I2CDriver* handle)
+{
+    _i2c_handle = handle;
+}
+/**
+ * @brief Destroy the SDP810::SDP810 object
+ * 
+ */
+SDP810::~SDP810()
+{
+}
+
+
+/**
+ * @brief 
+ * 
+ * @param channel 
+ */
+void SDP810::begin()
+
+{
+    uint8_t setting[2] = {0x36, 0x03};
+
+     _i2c_handle->send_bytes(setting, 2);
+}
+void SDP810::read()
+{
+    _i2c_handle->read_bytes(buffer, 9);    
+    conversionFactor = buffer[6] << 8 | buffer[7];
+    sensorRaw = (buffer[0] << 8 | buffer[1]);
+    sensorRaw = sensorRaw / conversionFactor; 
+}
+int16_t SDP810::getRaw()
+{
+    return sensorRaw;
+}
+int16_t SDP810::getVolume()
+{
+
+
+return 0;
+}

--- a/modules/hal_sensors/sensor_differentialpressure/drivers/SDP810.hpp
+++ b/modules/hal_sensors/sensor_differentialpressure/drivers/SDP810.hpp
@@ -1,0 +1,31 @@
+#ifndef SDP810_H
+#define SDP810_H
+
+#include <i2c_helper.hpp>
+
+
+#define SDP_addr 0x25
+
+class SDP810
+{
+public:
+
+    SDP810(I2CDriver* handle);
+    ~SDP810();
+    void begin();
+    void read();
+    int16_t getRaw();
+    int16_t getVolume();
+    
+private:
+double flow;
+int16_t sensorRaw;
+int16_t conversionFactor;
+uint8_t buffer[9];
+I2CDriver* _i2c_handle;
+};
+
+#endif // SDP810
+
+
+

--- a/modules/hal_sensors/sensor_differentialpressure/sensor_differentialpressure.cpp
+++ b/modules/hal_sensors/sensor_differentialpressure/sensor_differentialpressure.cpp
@@ -1,0 +1,15 @@
+#include <sensor_differentialpressure.hpp>
+
+void DifferentialPressureSensor::Initialize() {
+  sdp810_handle_->begin();
+}
+
+SensorData DifferentialPressureSensor::GetSensorData() {
+  sdp810_handle_->read();
+  sensor_data_.numOfBytes = 2;
+  sensor_data_.buffer[0] = sdp810_handle_->getRaw();
+  return sensor_data_;
+}
+
+void DifferentialPressureSensor::Uninitialize() {}
+

--- a/modules/hal_sensors/sensor_differentialpressure/sensor_differentialpressure.hpp
+++ b/modules/hal_sensors/sensor_differentialpressure/sensor_differentialpressure.hpp
@@ -1,0 +1,26 @@
+#ifndef SENSOR_DIFFERENTIALPRESSURE_H
+#define SENSOR_DIFFERENTIALPRESSURE_H
+
+#include "sensor_base.hpp"
+#include "drivers/SDP810.hpp"
+
+class DifferentialPressureSensor : public UniversalSensor {
+ public:
+  explicit DifferentialPressureSensor(i2c_peripheral_t i2c_peripheral)
+      : UniversalSensor(i2c_peripheral) {
+    i2c_handle_ = new I2CDriver(i2c_peripheral, i2c_speed_400KHz, kSensorI2CAddress_);
+    sdp810_handle_ = new SDP810(i2c_handle_);
+  }
+  void Initialize() override;
+  SensorData GetSensorData() override;
+  void Uninitialize() override;
+  ~DifferentialPressureSensor() {
+    Uninitialize();
+  }
+ private:
+  const uint8_t kSensorI2CAddress_ = 0x25;
+  I2CDriver *i2c_handle_;
+  SDP810 *sdp810_handle_;
+  SensorData sensor_data_{};
+};
+#endif  // SENSOR_DIFFERENTIALPRESSURE_H

--- a/modules/hal_sensors/sensor_fingerposition/CMakeLists.txt
+++ b/modules/hal_sensors/sensor_fingerposition/CMakeLists.txt
@@ -1,0 +1,11 @@
+file(GLOB HEADER_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+file(GLOB SOURCE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+# Make an automatic library - will be static or dynamic based on user setting
+add_library(hal_fingerposition ${SOURCE_LIST} ${HEADER_LIST})
+
+# We need this directory, and users of our library will need it too
+target_include_directories(hal_fingerposition PUBLIC .)
+
+target_link_libraries(hal_fingerposition PUBLIC i2c)
+target_link_libraries(hal_fingerposition PUBLIC hal_sensor)

--- a/modules/hal_sensors/sensor_fingerposition/drivers/ADS7138.cpp
+++ b/modules/hal_sensors/sensor_fingerposition/drivers/ADS7138.cpp
@@ -1,0 +1,77 @@
+#include "ADS7138.hpp"
+
+#ifdef __arm__
+#include "Arduino.h"
+#define sleep(ms) delay(ms)
+#else
+#define sleep(ms) usleep(1000*ms)
+#endif
+
+
+uint16_t createReg(uint8_t opcode, uint8_t regaddr){
+return (opcode | ((regaddr << 8)));
+}
+
+
+void ADS7138::writeRegister(uint8_t regAddr, uint8_t data) {
+    uint16_t reg = createReg(CONTINUOUS_W, regAddr);
+    _i2c_handle->write_reg(reg, data);              // Send address and register address bytes
+}
+
+void ADS7138::setRegister(uint8_t regAddr, uint8_t data) {
+    uint16_t reg = createReg(SET_BIT, regAddr);
+    _i2c_handle->write_reg(reg, data);                      // Send address and register address bytes
+}
+
+void ADS7138::clearRegister(uint8_t regAddr, uint8_t data) {
+    uint16_t reg = createReg(CLEAR_BIT, regAddr);
+    _i2c_handle->write_reg(reg, data);                  // Send address and register address bytes
+}
+
+uint8_t ADS7138::getRegister(uint8_t registerAddr) {
+    uint16_t reg = createReg(SINGLE_R, registerAddr);                      // Read Data from selected register
+    return _i2c_handle->read_reg(reg);
+}
+
+void ADS7138::initDefaultRead(void) {
+    setRegister(PIN_CFG, 0x0);                  // Channels are configured as Analog inps
+    setRegister(GENERAL_CFG, 0b10);             // SET CAL bit
+    setRegister(AUTO_SEQ_CH_SEL, 0xFF);         // xF --> Set all adc channels as inputs. enabled in scanning sequence.
+    setRegister(SEQUENCE_CFG, 0b01);            // Set Auto sequence mode on = 1. And 4th for sequence start.
+}
+void ADS7138::startReadSEQ(void) {
+    setRegister(SEQUENCE_CFG, 1 << 4);          // 4th bit starts the sequence.
+}
+
+void ADS7138::stopReadSEQ(void) {
+    clearRegister(SEQUENCE_CFG, 1 << 4);        // 4th bit reset the sequence.
+}
+
+void ADS7138::readADC(uint16_t *dest) {
+    startReadSEQ();
+    uint8_t temp[2] = {0x0, 0x0};
+    uint16_t buf[8];
+
+    for(int i = 0; i < 8; i++) {
+        getReading(temp);
+        buf[i] = (temp[0] << 4) | (temp[1] >> 4); // 12b conversion.
+        sleep(50);
+    }
+    reindexArray(dest, buf);
+    stopReadSEQ();
+}
+
+void ADS7138::reindexArray(uint16_t *dest, uint16_t *original) {
+    dest[0] = original[LOWER];
+    dest[1] = original[MID_L];
+    dest[2] = original[MID_M];
+    dest[3] = original[MID_H];
+    dest[4] = original[RE_L];
+    dest[5] = original[RE_H];
+    dest[6] = original[LI_L];
+    dest[7] = original[LI_H];
+}
+
+void ADS7138::getReading(uint8_t *buf) {
+    _i2c_handle->read_bytes(buf, TWO_BYTE);
+}

--- a/modules/hal_sensors/sensor_fingerposition/drivers/ADS7138.hpp
+++ b/modules/hal_sensors/sensor_fingerposition/drivers/ADS7138.hpp
@@ -1,0 +1,33 @@
+#ifndef ADS7138_H
+#define ADS7138_H
+
+#include <i2c_helper.hpp>
+#include "ADS7138_REGISTERS.hpp"
+
+#define ADS7138_ADDR 0x10
+#define TWO_BYTE 2
+
+class ADS7138 {
+private:
+    I2CDriver* _i2c_handle;
+
+    // Low Level I2C communication: 
+    void writeRegister(uint8_t regAddr, uint8_t data);
+    void setRegister(uint8_t regAddr, uint8_t data);
+    void clearRegister(uint8_t regAddr, uint8_t data);
+    uint8_t getRegister(uint8_t registerAddr);
+
+    void startReadSEQ(void);
+    void stopReadSEQ(void);
+    void reindexArray(uint16_t *dest, uint16_t *original);
+    void getReading(uint8_t *buf); // Get reading is private. It's not allowed to read one time only.
+public:
+    explicit ADS7138(I2CDriver* handle)
+        : _i2c_handle{handle} {} 
+
+    void initDefaultRead(void);
+    void readADC(uint16_t *dest);
+};
+
+#endif
+

--- a/modules/hal_sensors/sensor_fingerposition/drivers/ADS7138_REGISTERS.hpp
+++ b/modules/hal_sensors/sensor_fingerposition/drivers/ADS7138_REGISTERS.hpp
@@ -1,0 +1,31 @@
+#ifndef ADS7138_REGISTERS_H
+#define ADS7138_REGISTERS_H
+
+enum CHIP_REGISTERS {
+    GENERAL_CFG     =   0x01,
+    PIN_CFG         =   0x5,
+    SEQUENCE_CFG    =   0x10,
+    AUTO_SEQ_CH_SEL =   0x12,
+};
+
+enum CHIP_OPCODES {
+    SINGLE_R        = 0b00010000,
+    SINGLE_W        = 0b00001000,
+    SET_BIT         = 0b00011000,
+    CLEAR_BIT       = 0b00100000,
+    CONTINUOUS_R    = 0b00110000,
+    CONTINUOUS_W    = 0b00101000,
+};
+
+enum SENSOR_MAP_INDEX {
+    LOWER            = 5,
+    MID_L            = 4,
+    MID_M            = 3,
+    MID_H            = 6,
+    RE_L             = 7,
+    RE_H             = 0,
+    LI_L             = 2,
+    LI_H             = 1,       
+};
+
+#endif

--- a/modules/hal_sensors/sensor_fingerposition/sensor_fingerposition.cpp
+++ b/modules/hal_sensors/sensor_fingerposition/sensor_fingerposition.cpp
@@ -1,0 +1,18 @@
+#include <sensor_fingerposition.hpp>
+
+void FingerPositionSensor::Initialize() {
+  ads7138_handle_->initDefaultRead();
+}
+
+SensorData FingerPositionSensor::GetSensorData() {
+  const uint8_t kADC_channels_to_read = 8;
+  // 12-bit adc, 16-bit variable is the smallest size that fits this 12-bits.
+  // 16-bit is 2-bytes therefore the channels times 2
+  const uint8_t kAmount_of_bytes_to_read = 2*kADC_channels_to_read;
+  sensor_data_.numOfBytes = kAmount_of_bytes_to_read;
+  ads7138_handle_->readADC(sensor_data_.buffer);
+  return sensor_data_;
+}
+
+void FingerPositionSensor::Uninitialize() {}
+

--- a/modules/hal_sensors/sensor_fingerposition/sensor_fingerposition.hpp
+++ b/modules/hal_sensors/sensor_fingerposition/sensor_fingerposition.hpp
@@ -1,0 +1,25 @@
+#ifndef SENSOR_FINGERPOSITION_H
+#define SENSOR_FINGERPOSITION_H
+
+#include "sensor_base.hpp"
+#include "drivers/ADS7138.hpp"
+class FingerPositionSensor : public UniversalSensor {
+ public:
+  explicit FingerPositionSensor(i2c_peripheral_t i2c_peripheral)
+      : UniversalSensor(i2c_peripheral) {
+    i2c_handle_ = new I2CDriver(i2c_peripheral, i2c_speed_400KHz, kSensorI2CAddress_);
+    ads7138_handle_ = new ADS7138(i2c_handle_);
+  }
+  void Initialize() override;
+  SensorData GetSensorData() override;
+  void Uninitialize() override;
+  ~FingerPositionSensor() {
+    Uninitialize();
+  }
+ private:
+  const uint8_t kSensorI2CAddress_ = 0x10;
+  I2CDriver *i2c_handle_;
+  SensorData sensor_data_{};
+  ADS7138 *ads7138_handle_;
+};
+#endif  // SENSOR_FINGERPOSITION_H

--- a/modules/i2c/CMakeLists.txt
+++ b/modules/i2c/CMakeLists.txt
@@ -1,0 +1,10 @@
+file(GLOB HEADER_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+file(GLOB SOURCE_LIST ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+include_directories(".")
+# Make an automatic library - will be static or dynamic based on user setting
+add_library(i2c ${SOURCE_LIST} ${HEADER_LIST})
+
+# We need this directory, and users of our library will need it too
+target_include_directories(i2c PUBLIC .)
+

--- a/modules/i2c/i2c_helper.cpp
+++ b/modules/i2c/i2c_helper.cpp
@@ -1,0 +1,63 @@
+#include "i2c_helper.hpp"
+
+void I2CDriver::init(){
+    _i2c_peripheral->begin();
+}
+
+void I2CDriver::write_reg(uint16_t reg, uint8_t data){
+        _i2c_peripheral->beginTransmission(_i2c_addr);
+    _i2c_peripheral->write((reg >> 8) & 0xFF); // MSB of register address
+    _i2c_peripheral->write(reg & 0xFF);        // LSB of register address
+    _i2c_peripheral->write(data);                       // Data/setting to be sent to device.
+        _i2c_peripheral->endTransmission();
+}
+
+void I2CDriver::write_reg16(uint16_t reg, uint16_t data){
+    _i2c_peripheral->beginTransmission(_i2c_addr);
+    _i2c_peripheral->write((reg >> 8) & 0xFF); // MSB of register address
+    _i2c_peripheral->write(reg & 0xFF);        // LSB of register address
+    uint8_t temp;
+    temp = (data >> 8) & 0xff;
+    _i2c_peripheral->write(temp); // Data/setting to be sent to device
+    temp = data & 0xff;
+    _i2c_peripheral->write(temp);       // Data/setting to be sent to device         // Data/setting to be sent to device.
+    _i2c_peripheral->endTransmission();
+}
+
+uint8_t I2CDriver::read_reg (uint16_t reg){
+  uint8_t data;
+
+  _i2c_peripheral->beginTransmission(_i2c_addr);    // Address set on class instantiation
+  _i2c_peripheral->write((reg >> 8) & 0xFF); // MSB of register address
+  _i2c_peripheral->write(reg & 0xFF);        // LSB of register address
+  _i2c_peripheral->endTransmission(false);            // Send address and register address bytes
+  _i2c_peripheral->requestFrom(_i2c_addr, 1);
+  data = _i2c_peripheral->read(); // Read Data from selected register
+  return data;
+}
+
+uint16_t I2CDriver::read_reg16(uint16_t reg){
+  uint8_t data_low;
+  uint8_t data_high;
+  uint16_t data;
+  _i2c_peripheral->beginTransmission(_i2c_addr);    // Address set on class instantiation
+  _i2c_peripheral->write((reg >> 8) & 0xFF); // MSB of register address
+  _i2c_peripheral->write(reg & 0xFF);        // LSB of register address
+  _i2c_peripheral->endTransmission(false);            // Send address and register address bytes
+  _i2c_peripheral->requestFrom(_i2c_addr, 2);
+  data_high = _i2c_peripheral->read(); // Read Data from selected register
+  data_low = _i2c_peripheral->read();  // Read Data from selected register
+  data = (data_high << 8) | data_low;
+  return data;
+}
+
+void I2CDriver::read_bytes(uint8_t* buffer, uint8_t num_of_bytes){
+  _i2c_peripheral->requestFrom(_i2c_addr, num_of_bytes, true);
+  _i2c_peripheral->readBytes(buffer, num_of_bytes);
+}
+
+void I2CDriver::send_bytes(uint8_t* buffer, uint8_t num_of_bytes){
+  _i2c_peripheral->beginTransmission(_i2c_addr);
+  _i2c_peripheral->write(buffer, num_of_bytes);
+  _i2c_peripheral->endTransmission(true);
+}

--- a/modules/i2c/i2c_helper.hpp
+++ b/modules/i2c/i2c_helper.hpp
@@ -1,0 +1,39 @@
+#ifndef I2C_HELPER_H
+#define I2C_HELPER_H
+#include <stdint.h>
+
+#ifdef __arm__
+#include "Wire.h"
+#define i2c_peripheral_t TwoWire*
+#else
+#include "i2c_testclass.hpp"
+#define i2c_peripheral_t i2c_testClass*
+#endif
+
+typedef enum{
+i2c_speed_100KHz= 100000, i2c_speed_400KHz = 400000,
+}i2c_speed_t;
+
+class I2CDriver{
+    public:
+    I2CDriver(i2c_peripheral_t i2c_peripheral, i2c_speed_t speed, uint8_t i2c_addr){
+        this->_i2c_peripheral = i2c_peripheral;
+        this->_i2c_addr = i2c_addr;
+        this->_speed=speed;                                 
+    }
+    void init();
+    void write_reg(uint16_t reg, uint8_t data);
+    void write_reg16(uint16_t reg, uint16_t data);
+    uint8_t read_reg (uint16_t reg);
+    uint16_t read_reg16(uint16_t reg);
+	
+	void read_bytes(uint8_t* buffer, uint8_t num_of_bytes);
+	void send_bytes(uint8_t* buffer, uint8_t num_of_bytes); 
+	
+    private:
+    uint8_t _i2c_addr;
+    i2c_peripheral_t _i2c_peripheral;
+    i2c_speed_t _speed;
+};
+
+#endif

--- a/modules/i2c/i2c_testclass.hpp
+++ b/modules/i2c/i2c_testclass.hpp
@@ -1,0 +1,22 @@
+#ifndef I2C_TESTCLASS_H
+#define I2C_TESTCLASS_H
+#ifndef __arm__
+#include <stdint.h>
+#include <string.h>
+#include "gmock/gmock.h"  // Brings in Google Mock.
+
+class i2c_testClass{
+    public:
+    MOCK_METHOD0(begin, void());
+    MOCK_METHOD1(beginTransmission, void(uint8_t address));
+    MOCK_METHOD1(write, size_t(uint8_t ucData));
+    MOCK_METHOD2(write, size_t(const uint8_t *data, size_t quantity));
+    MOCK_METHOD0(endTransmission, void());
+    MOCK_METHOD2(requestFrom, uint8_t(uint8_t address, size_t quantity));
+    MOCK_METHOD2(readBytes, size_t( uint8_t *buffer, size_t length));
+    MOCK_METHOD0(read, int());
+    MOCK_METHOD3(requestFrom, uint8_t(uint8_t address, size_t quantity, bool stopBit));
+    MOCK_METHOD1(endTransmission, uint8_t(bool stopBit));
+};
+#endif
+#endif


### PR DESCRIPTION
What have I added:
- CMake buildsystem support. Now automatic CI/CD can be deployed using cmake. It also makes it easier to link libraries to test executables. Another way this can be useful is to exclude some libraries or code from compiling with the tests :)
- All previously made sensor libraries. (SDP810, VL6180, ADS7138).
- Library.json for the pio buildsystem

What have I changed:
- Some #include directives to match new folder structure

Why?
All those sensor libs in separate repo's where annoying. As in they take a lot of effort to maintain. To make the process of writing and improving those libs easier, this repo was made. This repo contains all used manikin libraries. Also low level libraries, for example the I2C wrapper and (eventually) DMA wrapper. 