### PR TITLE
-add change_address function to I2CDriver class

### DIFF
--- a/modules/hal_sensors/sensor_compression/sensor_compression.cpp
+++ b/modules/hal_sensors/sensor_compression/sensor_compression.cpp
@@ -11,6 +11,7 @@ sleep(ms) usleep(1000*ms)
 #endif
 
 void CompressionSensor::Initialize() {
+  i2c_handle_->change_address(kSensorI2CAddress_);
   initVL6180x();
   VL6180xDefautSettings();
 }

--- a/modules/hal_sensors/sensor_differentialpressure/sensor_differentialpressure.cpp
+++ b/modules/hal_sensors/sensor_differentialpressure/sensor_differentialpressure.cpp
@@ -1,6 +1,7 @@
 #include <sensor_differentialpressure.hpp>
 
 void DifferentialPressureSensor::Initialize() {
+  i2c_handle_->change_address(kSensorI2CAddress_);
   beginSDP810();
 }
 

--- a/modules/hal_sensors/sensor_fingerposition/sensor_fingerposition.cpp
+++ b/modules/hal_sensors/sensor_fingerposition/sensor_fingerposition.cpp
@@ -11,7 +11,8 @@ sleep(ms) usleep(1000*ms)
 #endif
 
 void FingerPositionSensor::Initialize() {
-  //ads7138_handle_->initDefaultRead();
+  i2c_handle_->change_address(kSensorI2CAddress_);
+  initDefaultRead();
 }
 
 SensorData FingerPositionSensor::GetSensorData() {

--- a/modules/i2c/i2c_helper.cpp
+++ b/modules/i2c/i2c_helper.cpp
@@ -4,6 +4,10 @@ void I2CDriver::init(){
     _i2c_peripheral->begin();
 }
 
+void I2CDriver::change_address(uint8_t new_i2c_address){
+  this->_i2c_addr = new_i2c_address;
+}
+
 void I2CDriver::write_reg(uint16_t reg, uint8_t data){
         _i2c_peripheral->beginTransmission(_i2c_addr);
     _i2c_peripheral->write((reg >> 8) & 0xFF); // MSB of register address

--- a/modules/i2c/i2c_helper.hpp
+++ b/modules/i2c/i2c_helper.hpp
@@ -21,9 +21,12 @@ class I2CDriver{
         this->_i2c_addr = i2c_addr;
         this->_speed=speed;                                 
     }
-    void init();
-    void change_address(uint8_t new_i2c_addr);
     
+    I2CDriver(i2c_peripheral_t i2c_peripheral, i2c_speed_t speed){
+        this->_i2c_peripheral = i2c_peripheral;
+        this->_speed=speed;                                 
+    }
+    void init();
     void write_reg(uint16_t reg, uint8_t data);
     void write_reg16(uint16_t reg, uint16_t data);
     uint8_t read_reg (uint16_t reg);

--- a/modules/i2c/i2c_helper.hpp
+++ b/modules/i2c/i2c_helper.hpp
@@ -22,6 +22,8 @@ class I2CDriver{
         this->_speed=speed;                                 
     }
     void init();
+    void change_address(uint8_t new_i2c_addr);
+    
     void write_reg(uint16_t reg, uint8_t data);
     void write_reg16(uint16_t reg, uint16_t data);
     uint8_t read_reg (uint16_t reg);


### PR DESCRIPTION
What has been added:
- change_address function has been added to the I2CDriver class
- second constructor to I2CDriver class without the i2caddress parameter

What has changed:
- Every sensor class Initialize function now sets the i2caddress by default, so I2C handle can be shared among classes
