### PR TITLE
Hal lib gpio

### DIFF
--- a/library.json
+++ b/library.json
@@ -5,6 +5,7 @@
         "srcFilter": "+<*> -<*/test/> -<hal_sensors/*/test>",
         "flags": [
             "-I modules/i2c/src",
+            "-I modules/hal_gpio/src",
             "-I modules/hal_sensors/sensor_base/src",
             "-I modules/hal_sensors/sensor_compression/src",
             "-I modules/hal_sensors/sensor_differentialpressure/src",

--- a/modules/hal_gpio/src/gpio.cpp
+++ b/modules/hal_gpio/src/gpio.cpp
@@ -51,11 +51,14 @@ namespace hal::gpio {
     }
 
     void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength) {
-        PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength == kGPIOStrongDriveStrength ? 1 : 0;
+        if (driver_strength <= 1 && driver_strength > -1) {
+        PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength;
+        }
     }
 
     void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function) {
-        PORT->Group[port_num].PINCFG[pin_num].bit.PMUXEN = 0x01;
+        PORT->Group[port_num].PINCFG[pin_num].bit.PMUXEN = 0x01;  // Enable the pin mux function
+        // There is a seperate pin mux for even and odd pin numbers (See datasheet)
         if (pin_num % 2 == 0) {
             PORT->Group[port_num].PMUX[pin_num].bit.PMUXE |= pin_function;
         } else {
@@ -72,11 +75,11 @@ namespace hal::gpio {
     }
 
     uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num) {
-        return (PORT->Group[port_num].OUT.reg & 1 << pin_num) | (1 << pin_num);
+        return (PORT->Group[port_num].OUT.reg >> pin_num) & 1;
     }
 
     uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num) {
-        return (PORT->Group[port_num].DIR.reg & 1 << pin_num) | (1 << pin_num);
+        return (PORT->Group[port_num].DIR.reg >> pin_num) & 1;
     }
 
     uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num) {

--- a/modules/hal_gpio/src/gpio.cpp
+++ b/modules/hal_gpio/src/gpio.cpp
@@ -28,14 +28,6 @@
 #include <gpio.hpp>
 #include <sam.h>
 
-#ifdef SAMD21G18A
-#include <samd21/include/samd21g18a.h>
-#elif SAMD21E18A
-#include <samd21/include/samd21e18a.h>
-#elif SAMD51G19A
-#include <samd51/include/samd51g19a.h>
-#endif
-
 namespace hal::gpio {
 
     void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level) {

--- a/modules/hal_gpio/src/gpio.cpp
+++ b/modules/hal_gpio/src/gpio.cpp
@@ -9,45 +9,92 @@
 #include <samd51/include/samd51g19a.h>
 #endif
 
-namespace hal::gpio{
+namespace hal::gpio
+{
 
-
-void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level){
-if(level){
-    PORT->Group[port_num].OUTSET.reg |= 1 << pin_num;
-}
-else{
-    PORT->Group[port_num].OUTCLR.reg |= 1 << pin_num;
-}
-}
-
-void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num){
-    PORT->Group[port_num].OUTTGL.reg |= 1 << pin_num;
-}
-
-void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction){
-    if(direction){
-        PORT->Group[port_num].DIRSET.reg |= 1 << pin_num;
+    void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level)
+    {
+        if (level)
+        {
+            PORT->Group[port_num].OUTSET.reg |= 1 << pin_num;
+        }
+        else
+        {
+            PORT->Group[port_num].OUTCLR.reg |= 1 << pin_num;
+        }
     }
-    else{
-        PORT->Group[port_num].DIRCLR.reg |= 1 << pin_num;
+
+    void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num)
+    {
+        PORT->Group[port_num].OUTTGL.reg |= 1 << pin_num;
     }
-}
 
-void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength){
-    PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength ==  kGPIOStrongDriveStrength ? 1 : 0;
-}
-
-void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function){
-
-}
-
-void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode){
-    if(sampling_mode == kGPIOSampleContinuously){
-        PORT->Group[port_num].CTRL.reg |= 1 << pin_num;
+    void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction)
+    {
+        if (direction)
+        {
+            PORT->Group[port_num].DIRSET.reg |= 1 << pin_num;
+        }
+        else
+        {
+            PORT->Group[port_num].DIRCLR.reg |= 1 << pin_num;
+        }
     }
-    else{
-        PORT->Group[port_num].CTRL.reg &= ~(1 << pin_num);
+
+    void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength)
+    {
+        PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength == kGPIOStrongDriveStrength ? 1 : 0;
     }
-}
+
+    void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function)
+    {
+        PORT->Group[port_num].PINCFG[pin_num].bit.PMUXEN = 0x01;
+        if (pin_num % 2 == 0)
+        {
+            PORT->Group[port_num].PMUX[pin_num].bit.PMUXE |= pin_function;
+        }
+        else
+        {
+            PORT->Group[port_num].PMUX[pin_num].bit.PMUXO |= pin_function;
+        }
+    }
+
+    void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode)
+    {
+        if (sampling_mode == kGPIOSampleContinuously)
+        {
+            PORT->Group[port_num].CTRL.reg |= 1 << pin_num;
+        }
+        else
+        {
+            PORT->Group[port_num].CTRL.reg &= ~(1 << pin_num);
+        }
+    }
+
+    uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num)
+    {
+        return (PORT->Group[port_num].OUT.reg & 1 << pin_num) | (1 << pin_num);
+    }
+
+    uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num)
+    {
+        return (PORT->Group[port_num].DIR.reg & 1 << pin_num) | (1 << pin_num);
+    }
+
+    uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num)
+    {
+        return (PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR);
+    }
+
+    uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num)
+    {
+        if (pin_num % 2 == 0)
+        {
+            return PORT->Group[port_num].PMUX[pin_num].bit.PMUXE;
+        }
+        else
+        {
+            return PORT->Group[port_num].PMUX[pin_num].bit.PMUXO;
+        }
+    }
 }

--- a/modules/hal_gpio/src/gpio.cpp
+++ b/modules/hal_gpio/src/gpio.cpp
@@ -1,0 +1,53 @@
+#include <gpio.hpp>
+#include <sam.h>
+
+#ifdef SAMD21G18A
+#include <samd21/include/samd21g18a.h>
+#elif SAMD21E18A
+#include <samd21/include/samd21e18a.h>
+#elif SAMD51G19A
+#include <samd51/include/samd51g19a.h>
+#endif
+
+namespace hal::gpio{
+
+
+void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level){
+if(level){
+    PORT->Group[port_num].OUTSET.reg |= 1 << pin_num;
+}
+else{
+    PORT->Group[port_num].OUTCLR.reg |= 1 << pin_num;
+}
+}
+
+void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num){
+    PORT->Group[port_num].OUTTGL.reg |= 1 << pin_num;
+}
+
+void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction){
+    if(direction){
+        PORT->Group[port_num].DIRSET.reg |= 1 << pin_num;
+    }
+    else{
+        PORT->Group[port_num].DIRCLR.reg |= 1 << pin_num;
+    }
+}
+
+void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength){
+    PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength ==  kGPIOStrongDriveStrength ? 1 : 0;
+}
+
+void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function){
+
+}
+
+void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode){
+    if(sampling_mode == kGPIOSampleContinuously){
+        PORT->Group[port_num].CTRL.reg |= 1 << pin_num;
+    }
+    else{
+        PORT->Group[port_num].CTRL.reg &= ~(1 << pin_num);
+    }
+}
+}

--- a/modules/hal_gpio/src/gpio.cpp
+++ b/modules/hal_gpio/src/gpio.cpp
@@ -1,3 +1,30 @@
+/* *******************************************************************************************
+ * Copyright (c) 2023 by RobotPatient Simulators
+ *
+ * Authors: Thomas van den Oever en Victor Hogeweij
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction,
+ *
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so,
+ *
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+***********************************************************************************************/
 #include <gpio.hpp>
 #include <sam.h>
 
@@ -9,92 +36,66 @@
 #include <samd51/include/samd51g19a.h>
 #endif
 
-namespace hal::gpio
-{
+namespace hal::gpio {
 
-    void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level)
-    {
-        if (level)
-        {
+    void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level) {
+        if (level) {
             PORT->Group[port_num].OUTSET.reg |= 1 << pin_num;
-        }
-        else
-        {
+        } else {
             PORT->Group[port_num].OUTCLR.reg |= 1 << pin_num;
         }
     }
 
-    void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num)
-    {
+    void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num) {
         PORT->Group[port_num].OUTTGL.reg |= 1 << pin_num;
     }
 
-    void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction)
-    {
-        if (direction)
-        {
+    void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction) {
+        if (direction) {
             PORT->Group[port_num].DIRSET.reg |= 1 << pin_num;
-        }
-        else
-        {
+        } else {
             PORT->Group[port_num].DIRCLR.reg |= 1 << pin_num;
         }
     }
 
-    void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength)
-    {
+    void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength) {
         PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength == kGPIOStrongDriveStrength ? 1 : 0;
     }
 
-    void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function)
-    {
+    void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function) {
         PORT->Group[port_num].PINCFG[pin_num].bit.PMUXEN = 0x01;
-        if (pin_num % 2 == 0)
-        {
+        if (pin_num % 2 == 0) {
             PORT->Group[port_num].PMUX[pin_num].bit.PMUXE |= pin_function;
-        }
-        else
-        {
+        } else {
             PORT->Group[port_num].PMUX[pin_num].bit.PMUXO |= pin_function;
         }
     }
 
-    void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode)
-    {
-        if (sampling_mode == kGPIOSampleContinuously)
-        {
+    void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode) {
+        if (sampling_mode == kGPIOSampleContinuously) {
             PORT->Group[port_num].CTRL.reg |= 1 << pin_num;
-        }
-        else
-        {
+        } else {
             PORT->Group[port_num].CTRL.reg &= ~(1 << pin_num);
         }
     }
 
-    uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num)
-    {
+    uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num) {
         return (PORT->Group[port_num].OUT.reg & 1 << pin_num) | (1 << pin_num);
     }
 
-    uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num)
-    {
+    uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num) {
         return (PORT->Group[port_num].DIR.reg & 1 << pin_num) | (1 << pin_num);
     }
 
-    uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num)
-    {
+    uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num) {
         return (PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR);
     }
 
-    uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num)
-    {
-        if (pin_num % 2 == 0)
-        {
+    uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num) {
+        if (pin_num % 2 == 0) {
             return PORT->Group[port_num].PMUX[pin_num].bit.PMUXE;
-        }
-        else
-        {
+        } else {
             return PORT->Group[port_num].PMUX[pin_num].bit.PMUXO;
         }
     }
-}
+}  // namespace hal::gpio

--- a/modules/hal_gpio/src/gpio.hpp
+++ b/modules/hal_gpio/src/gpio.hpp
@@ -80,17 +80,88 @@ namespace hal::gpio {
         kGPIOEventClr,
         kGPIOEventTgl
     } GPIOInputEvent;
-
+    /**
+     * @brief Set the (output) level of the pin given.
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @param level This value is either 0 or 1. Where 0 means off, 1 means on (if pin is not inverted :) )..
+     */
     void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level);
+    /**
+     * @brief Toggle (output) level of the given pin.
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     */
     void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num);
+    /**
+     * @brief Set the pin direction (input or output) of the given pin.
+     * 
+     * @param port_num The port the pin is located on; Example:  PB17 -> PortB, use kGPIOPortB..
+     * @param pin_num The pin number; Example: PB17 -> pin 17;
+     * @param direction The direction of pin (input or output); Use the kGPIODirInput or kGPIODirOutput macro for this.
+     */
     void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction);
+    /**
+     * @brief Set the pin function of the given pin. (See datasheet pin mux section...)
+     *        For example; When using SERCOM (most of the time) on the pin, the function is either c or d.
+     *        Tip! look in datasheet of the chip for exact mapping data.
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @param pin_function The pin function(group) to assign to the pin. (See datasheet and the GPIOPinFunction enum above!)
+     */
     void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function);
+    /**
+     * @brief Set the pin drive strength of the given pin. 
+     *        2 mA for normal mode, 8 mA for strong mode at 3.3V supply voltage (see datasheet)
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @param drive_strength The drivestrength to be assigned to the pin. Use enum GPIODriveStrength for this.
+     */
     void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength drive_strength);
+    /**
+     * @brief Set the sampling mode for the given pin.
+     *        Input pins can be sampled either on demand or continuously
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @param sampling_mode The sampling mode to apply to the pin, use enum GPIOSamplingMode for this.
+     */
     void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode);
-
+    /**
+     * @brief Get the current pin level of the given (input) pin.
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @return uint8_t The current pin level of the input pin.
+     */
     uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num);
+    /**
+     * @brief Get the currently set pin direction (input or output)
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @return uint8_t The current pin direction of the given pin.
+     */
     uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num);
+    /**
+     * @brief Get the currently set drivestrength of output pin. 
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @return uint8_t The current drive strength of the given pin.
+     */
     uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num);
+    /**
+     * @brief Get the currently set pin function for the given pin.
+     * 
+     * @param port_num The port the pin is located on; Example:  PA17 -> PortA, use kGPIOPortA..
+     * @param pin_num The pin number; Example: PA17 -> pin 17;
+     * @return uint8_t The pin function of the given pin.
+     */
     uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num);
 
 }  // namespace hal::gpio

--- a/modules/hal_gpio/src/gpio.hpp
+++ b/modules/hal_gpio/src/gpio.hpp
@@ -73,7 +73,7 @@ namespace hal::gpio {
         kGPIOSampleOnDemand,
         kGPIOSampleContinuously
     } GPIOSamplingMode;
-
+    // TODO(Hoog-V): Implement GPIOEvents.
     typedef enum {
         kGPIOEventOut,
         kGPIOEventSet,

--- a/modules/hal_gpio/src/gpio.hpp
+++ b/modules/hal_gpio/src/gpio.hpp
@@ -1,29 +1,52 @@
+/* *******************************************************************************************
+ * Copyright (c) 2023 by RobotPatient Simulators
+ *
+ * Authors: Thomas van den Oever en Victor Hogeweij
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction,
+ *
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so,
+ *
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+***********************************************************************************************/
 #ifndef GPIO_HPP
 #define GPIO_HPP
 
 #include <stdint.h>
 
-namespace hal::gpio
-{
+namespace hal::gpio {
 
     inline constexpr uint8_t kGPIODirInput = 0x00;
     inline constexpr uint8_t kGPIODirOutput = 0x01;
 
-    typedef enum
-    {
+    typedef enum {
         kGPIOPortA,
         kGPIOPortB,
         kGPIOPortC
     } GPIOPort;
 
-    typedef enum
-    {
+    typedef enum {
         kGPIONormalDriveStrength,
         kGPIOStrongDriveStrength
     } GPIODriveStrength;
 
-    typedef enum
-    {
+    typedef enum {
         kGPIOFunctionA = 0x0,
         kGPIOFunctionB = 0x1,
         kGPIOFunctionC = 0x2,
@@ -40,21 +63,18 @@ namespace hal::gpio
         kGPIOFunctionN = 0xD
     } GPIOPinFunction;
 
-    typedef enum
-    {
+    typedef enum {
         kGPIOPullDown,
         kGPIOPullUp,
         kGPIONoPull
     } GPIOPull;
 
-    typedef enum
-    {
+    typedef enum {
         kGPIOSampleOnDemand,
         kGPIOSampleContinuously
     } GPIOSamplingMode;
 
-    typedef enum
-    {
+    typedef enum {
         kGPIOEventOut,
         kGPIOEventSet,
         kGPIOEventClr,
@@ -73,6 +93,6 @@ namespace hal::gpio
     uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num);
     uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num);
 
-}
+}  // namespace hal::gpio
 
 #endif

--- a/modules/hal_gpio/src/gpio.hpp
+++ b/modules/hal_gpio/src/gpio.hpp
@@ -3,72 +3,76 @@
 
 #include <stdint.h>
 
+namespace hal::gpio
+{
 
-namespace hal::gpio{
+    inline constexpr uint8_t kGPIODirInput = 0x00;
+    inline constexpr uint8_t kGPIODirOutput = 0x01;
 
-inline constexpr uint8_t kGPIODirInput = 0x00;
-inline constexpr uint8_t kGPIODirOutput = 0x01;
+    typedef enum
+    {
+        kGPIOPortA,
+        kGPIOPortB,
+        kGPIOPortC
+    } GPIOPort;
 
-typedef enum{
-    kGPIOPortA,
-    kGPIOPortB,
-    kGPIOPortC
-}GPIOPort;
+    typedef enum
+    {
+        kGPIONormalDriveStrength,
+        kGPIOStrongDriveStrength
+    } GPIODriveStrength;
 
-typedef enum{
-    kGPIONormalDriveStrength,
-    kGPIOStrongDriveStrength
-}GPIODriveStrength;
+    typedef enum
+    {
+        kGPIOFunctionA = 0x0,
+        kGPIOFunctionB = 0x1,
+        kGPIOFunctionC = 0x2,
+        kGPIOFunctionD = 0x3,
+        kGPIOFunctionE = 0x4,
+        kGPIOFunctionF = 0x5,
+        kGPIOFunctionG = 0x6,
+        kGPIOFunctionH = 0x7,
+        kGPIOFunctionI = 0x8,
+        kGPIOFunctionJ = 0x9,
+        kGPIOFunctionK = 0xA,
+        kGPIOFunctionL = 0xB,
+        kGPIOFunctionM = 0xC,
+        kGPIOFunctionN = 0xD
+    } GPIOPinFunction;
 
-typedef enum{
- kGPIOFunctionA,
- kGPIOFunctionB,
- kGPIOFunctionC,
- kGPIOFunctionD,
- kGPIOFunctionE,
- kGPIOFunctionF,
- kGPIOFunctionG
-}GPIOPinFunction;
+    typedef enum
+    {
+        kGPIOPullDown,
+        kGPIOPullUp,
+        kGPIONoPull
+    } GPIOPull;
 
-typedef enum{
-kGPIOPullDown,
-kGPIOPullUp,
-kGPIONoPull
-}GPIOPull;
+    typedef enum
+    {
+        kGPIOSampleOnDemand,
+        kGPIOSampleContinuously
+    } GPIOSamplingMode;
 
-typedef enum{
-kGPIOSampleOnDemand,
-kGPIOSampleContinuously
-}GPIOSamplingMode;
+    typedef enum
+    {
+        kGPIOEventOut,
+        kGPIOEventSet,
+        kGPIOEventClr,
+        kGPIOEventTgl
+    } GPIOInputEvent;
 
-typedef enum{
-kGPIOEventOut,
-kGPIOEventSet,
-kGPIOEventClr,
-kGPIOEventTgl
-}GPIOInputEvent;
+    void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level);
+    void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num);
+    void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction);
+    void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function);
+    void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength drive_strength);
+    void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode);
 
-void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level);
-void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num);
-void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction);
-void SetGPIOPinDriveSetting(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength);
-void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function);
-void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength drive_strength);
-void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode);
-
-
-uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num);
-uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num);
-uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num);
-uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num);
+    uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num);
+    uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num);
+    uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num);
+    uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num);
 
 }
-
-
-
-
-
-
-
 
 #endif

--- a/modules/hal_gpio/src/gpio.hpp
+++ b/modules/hal_gpio/src/gpio.hpp
@@ -1,0 +1,74 @@
+#ifndef GPIO_HPP
+#define GPIO_HPP
+
+#include <stdint.h>
+
+
+namespace hal::gpio{
+
+inline constexpr uint8_t kGPIODirInput = 0x00;
+inline constexpr uint8_t kGPIODirOutput = 0x01;
+
+typedef enum{
+    kGPIOPortA,
+    kGPIOPortB,
+    kGPIOPortC
+}GPIOPort;
+
+typedef enum{
+    kGPIONormalDriveStrength,
+    kGPIOStrongDriveStrength
+}GPIODriveStrength;
+
+typedef enum{
+ kGPIOFunctionA,
+ kGPIOFunctionB,
+ kGPIOFunctionC,
+ kGPIOFunctionD,
+ kGPIOFunctionE,
+ kGPIOFunctionF,
+ kGPIOFunctionG
+}GPIOPinFunction;
+
+typedef enum{
+kGPIOPullDown,
+kGPIOPullUp,
+kGPIONoPull
+}GPIOPull;
+
+typedef enum{
+kGPIOSampleOnDemand,
+kGPIOSampleContinuously
+}GPIOSamplingMode;
+
+typedef enum{
+kGPIOEventOut,
+kGPIOEventSet,
+kGPIOEventClr,
+kGPIOEventTgl
+}GPIOInputEvent;
+
+void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level);
+void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num);
+void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction);
+void SetGPIOPinDriveSetting(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength);
+void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function);
+void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength drive_strength);
+void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode);
+
+
+uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num);
+uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num);
+uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num);
+uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num);
+
+}
+
+
+
+
+
+
+
+
+#endif

--- a/modules/hal_gpio/src/platform/samd21/gpio_registers.hpp
+++ b/modules/hal_gpio/src/platform/samd21/gpio_registers.hpp
@@ -1,0 +1,4 @@
+#ifndef GPIO_REGISTERS_G18_HPP
+#define GPIO_REGISTERS_G18_HPP
+
+#endif

--- a/modules/hal_gpio/src/platform/samd21/gpio_registers.hpp
+++ b/modules/hal_gpio/src/platform/samd21/gpio_registers.hpp
@@ -1,4 +1,0 @@
-#ifndef GPIO_REGISTERS_G18_HPP
-#define GPIO_REGISTERS_G18_HPP
-
-#endif

--- a/modules/hal_gpio/src/platform/samd51/gpio_registers.hpp
+++ b/modules/hal_gpio/src/platform/samd51/gpio_registers.hpp
@@ -1,0 +1,4 @@
+#ifndef GPIO_REGISTERS_HPP
+#define GPIO_REGISTERS_HPP
+
+#endif

--- a/modules/hal_gpio/src/platform/samd51/gpio_registers.hpp
+++ b/modules/hal_gpio/src/platform/samd51/gpio_registers.hpp
@@ -1,4 +1,0 @@
-#ifndef GPIO_REGISTERS_HPP
-#define GPIO_REGISTERS_HPP
-
-#endif


### PR DESCRIPTION
Why this PR?

Jordi is busy building the power supply for the baby manikin. He needs access to easy to use gpio hal. The state of the hal gpio seems to be 75% complete with most functions implemented.. It is also a good checkup.. This way the GitHub workflows can help us determine whether changes are necessary.

What has been added:

- Easy to use hal for driving gpio using the native pinning of the device used. (PA, PB, PC, ETC).