### PR TITLE
Add functional unit tests for the gpio lib

### DIFF
--- a/modules/hal_gpio/src/gpio.cpp
+++ b/modules/hal_gpio/src/gpio.cpp
@@ -30,67 +30,67 @@
 
 namespace hal::gpio {
 
-    void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level) {
-        if (level) {
-            PORT->Group[port_num].OUTSET.reg |= 1 << pin_num;
-        } else {
-            PORT->Group[port_num].OUTCLR.reg |= 1 << pin_num;
-        }
-    }
+void SetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num, uint8_t level) {
+  if (level) {
+    PORT->Group[port_num].OUTSET.reg |= 1 << pin_num;
+  } else {
+    PORT->Group[port_num].OUTCLR.reg |= 1 << pin_num;
+  }
+}
 
-    void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num) {
-        PORT->Group[port_num].OUTTGL.reg |= 1 << pin_num;
-    }
+void ToggleGPIOPin(GPIOPort port_num, uint8_t pin_num) {
+  PORT->Group[port_num].OUTTGL.reg |= 1 << pin_num;
+}
 
-    void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction) {
-        if (direction) {
-            PORT->Group[port_num].DIRSET.reg |= 1 << pin_num;
-        } else {
-            PORT->Group[port_num].DIRCLR.reg |= 1 << pin_num;
-        }
-    }
+void SetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num, uint8_t direction) {
+  if (direction) {
+    PORT->Group[port_num].DIRSET.reg |= 1 << pin_num;
+  } else {
+    PORT->Group[port_num].DIRCLR.reg |= 1 << pin_num;
+  }
+}
 
-    void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength) {
-        if (driver_strength <= 1 && driver_strength > -1) {
-        PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength;
-        }
-    }
+void SetGPIOPinDriveStrength(GPIOPort port_num, uint8_t pin_num, GPIODriveStrength driver_strength) {
+  if (driver_strength <= 1 && driver_strength > -1) {
+    PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR = driver_strength;
+  }
+}
 
-    void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function) {
-        PORT->Group[port_num].PINCFG[pin_num].bit.PMUXEN = 0x01;  // Enable the pin mux function
-        // There is a seperate pin mux for even and odd pin numbers (See datasheet)
-        if (pin_num % 2 == 0) {
-            PORT->Group[port_num].PMUX[pin_num].bit.PMUXE |= pin_function;
-        } else {
-            PORT->Group[port_num].PMUX[pin_num].bit.PMUXO |= pin_function;
-        }
-    }
+void SetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num, GPIOPinFunction pin_function) {
+  PORT->Group[port_num].PINCFG[pin_num].bit.PMUXEN = 0x01;  // Enable the pin mux function
+  // There is a seperate pin mux for even and odd pin numbers (See datasheet)
+  if (pin_num % 2 == 0) {
+    PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXE |= pin_function;
+  } else {
+    PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXO |= pin_function;
+  }
+}
 
-    void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode) {
-        if (sampling_mode == kGPIOSampleContinuously) {
-            PORT->Group[port_num].CTRL.reg |= 1 << pin_num;
-        } else {
-            PORT->Group[port_num].CTRL.reg &= ~(1 << pin_num);
-        }
-    }
+void SetGPIOPinSamplingMode(GPIOPort port_num, uint8_t pin_num, GPIOSamplingMode sampling_mode) {
+  if (sampling_mode == kGPIOSampleContinuously) {
+    PORT->Group[port_num].CTRL.reg |= 1 << pin_num;
+  } else {
+    PORT->Group[port_num].CTRL.reg &= ~(1 << pin_num);
+  }
+}
 
-    uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num) {
-        return (PORT->Group[port_num].OUT.reg >> pin_num) & 1;
-    }
+uint8_t GetGPIOPinLevel(GPIOPort port_num, uint8_t pin_num) {
+  return (PORT->Group[port_num].OUT.reg >> pin_num) & 1;
+}
 
-    uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num) {
-        return (PORT->Group[port_num].DIR.reg >> pin_num) & 1;
-    }
+uint8_t GetGPIOPinDirection(GPIOPort port_num, uint8_t pin_num) {
+  return (PORT->Group[port_num].DIR.reg >> pin_num) & 1;
+}
 
-    uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num) {
-        return (PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR);
-    }
+uint8_t GetGPIODriveStrength(GPIOPort port_num, uint8_t pin_num) {
+  return (PORT->Group[port_num].PINCFG[pin_num].bit.DRVSTR);
+}
 
-    uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num) {
-        if (pin_num % 2 == 0) {
-            return PORT->Group[port_num].PMUX[pin_num].bit.PMUXE;
-        } else {
-            return PORT->Group[port_num].PMUX[pin_num].bit.PMUXO;
-        }
-    }
+uint8_t GetGPIOPinFunction(GPIOPort port_num, uint8_t pin_num) {
+  if (pin_num % 2 == 0) {
+    return PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXE;
+  } else {
+    return PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXO;
+  }
+}
 }  // namespace hal::gpio

--- a/modules/hal_gpio/test/CMakeLists.txt
+++ b/modules/hal_gpio/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+set(This hal_gpio_unit_test)
+
+set(Sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/gpio.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/gpio.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/sam.h
+        hal_gpio_unit_test.cc
+        )
+
+# We need this directory, and users of our library will need it too
+
+
+add_executable(${This} ${Sources})
+target_link_libraries(${This}  gtest_main gmock_main)
+set_property(TARGET ${This} PROPERTY CXX_STANDARD 17)
+
+target_include_directories(${This} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../src/
+                                          ${CMAKE_CURRENT_SOURCE_DIR}/mocks/)
+add_test(
+        NAME ${This}
+        COMMAND ${This}
+)

--- a/modules/hal_gpio/test/hal_gpio_unit_test.cc
+++ b/modules/hal_gpio/test/hal_gpio_unit_test.cc
@@ -1,7 +1,7 @@
 /* *******************************************************************************************
  * Copyright (c) 2023 by RobotPatient Simulators
  *
- * Authors: Richard Kroesen en Victor Hogeweij
+ * Authors: Victor Hogeweij
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
@@ -25,22 +25,19 @@
  * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  ***********************************************************************************************/
-
-#include <gmock/gmock.h>
-#include <gpio.hpp>
 #include <sam.h>
+#include <gpio.hpp>
+#include <gmock/gmock.h>
 
 static Port MockPort;
 volatile Port *PORT = &MockPort;
 using namespace hal::gpio;
 
-TEST(HAL_GPIO_TEST, DIRSET)
-{
+TEST(HAL_GPIO_TEST, DIRSET) {
   uint32_t expected_output = 0;
   PORT->Group[0].DIRSET.reg = 0;
   PORT->Group[0].DIRCLR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output |= 1 << i;
     SetGPIOPinDirection(kGPIOPortA, i, kGPIODirOutput);
     EXPECT_EQ(PORT->Group[0].DIRSET.reg, expected_output);
@@ -48,14 +45,12 @@ TEST(HAL_GPIO_TEST, DIRSET)
   }
 }
 
-TEST(HAL_GPIO_TEST, DIRCLR)
-{
+TEST(HAL_GPIO_TEST, DIRCLR) {
   uint32_t expected_output = 0;
   PORT->Group[0].DIRSET.reg = 0;
   PORT->Group[0].DIRCLR.reg = 0;
   const uint8_t regsize_in_bits = sizeof(PORT->Group[0].DIRCLR.reg) * 8;
-  for (uint8_t i = 0; i < regsize_in_bits; i++)
-  {
+  for (uint8_t i = 0; i < regsize_in_bits; i++) {
     expected_output |= 1 << i;
     SetGPIOPinDirection(kGPIOPortA, i, kGPIODirInput);
     EXPECT_EQ(PORT->Group[0].DIRCLR.reg, expected_output);
@@ -63,55 +58,48 @@ TEST(HAL_GPIO_TEST, DIRCLR)
   }
 }
 
-TEST(HAL_GPIO_TEST, DRIVESTRENGTH)
-{
+TEST(HAL_GPIO_TEST, DRIVESTRENGTH) {
   uint32_t expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     PORT->Group[0].PINCFG[i].reg = 0;
     expected_output = 0;
     SetGPIOPinDriveStrength(kGPIOPortA, i, kGPIONormalDriveStrength);
     EXPECT_EQ(PORT->Group[0].PINCFG[i].reg, expected_output);
+    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
     expected_output = 1 << 6;
     SetGPIOPinDriveStrength(kGPIOPortA, i, kGPIOStrongDriveStrength);
     EXPECT_EQ(PORT->Group[0].PINCFG[i].reg, expected_output);
+    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), 1);
   }
 }
 
-TEST(HAL_GPIO_TEST, PINFUNCTION)
-{
+TEST(HAL_GPIO_TEST, PINFUNCTION) {
   uint32_t output = 0;
-  for (uint8_t pin_group = 0; pin_group < PORT_GROUP_NUM; pin_group++)
-  {
-    for (uint8_t pin_func = 0; pin_func < 4; pin_func++)
-    {
-      for (uint8_t pin_num = 0; pin_num < 32; pin_num++)
-      {
+  for (uint8_t pin_group = 0; pin_group < PORT_GROUP_NUM; pin_group++) {
+    for (uint8_t pin_func = 0; pin_func < 4; pin_func++) {
+      for (uint8_t pin_num = 0; pin_num < 32; pin_num++) {
         PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXO = 0;
         PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXE = 0;
-        SetGPIOPinFunction((GPIOPort)pin_group, pin_num, (GPIOPinFunction)pin_func);
-        if (pin_num % 2)
-        {
+        SetGPIOPinFunction((GPIOPort) pin_group, pin_num, (GPIOPinFunction) pin_func);
+        if (pin_num % 2) {
           output = PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXO;
           EXPECT_EQ(output, pin_func);
-        }
-        else
-        {
+          EXPECT_EQ(GetGPIOPinFunction((GPIOPort) pin_group, pin_num), pin_func);
+        } else {
           output = PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXE;
           EXPECT_EQ(output, pin_func);
+          EXPECT_EQ(GetGPIOPinFunction((GPIOPort) pin_group, pin_num), pin_func);
         }
       }
     }
   }
 }
 
-TEST(HAL_GPIO_TEST, OUTSET)
-{
+TEST(HAL_GPIO_TEST, OUTSET) {
   uint32_t expected_output = 0;
   PORT->Group[0].OUTSET.reg = 0;
   PORT->Group[0].OUTCLR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output |= 1 << i;
     SetGPIOPinLevel(kGPIOPortA, i, 1);
     EXPECT_EQ(PORT->Group[0].OUTSET.reg, expected_output);
@@ -119,13 +107,11 @@ TEST(HAL_GPIO_TEST, OUTSET)
   }
 }
 
-TEST(HAL_GPIO_TEST, OUTCLR)
-{
+TEST(HAL_GPIO_TEST, OUTCLR) {
   uint32_t expected_output = 0;
   PORT->Group[0].OUTSET.reg = 0;
   PORT->Group[0].OUTCLR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output |= 1 << i;
     SetGPIOPinLevel(kGPIOPortA, i, 0);
     EXPECT_EQ(PORT->Group[0].OUTCLR.reg, expected_output);
@@ -133,24 +119,20 @@ TEST(HAL_GPIO_TEST, OUTCLR)
   }
 }
 
-TEST(HAL_GPIO_TEST, TOGGLE)
-{
+TEST(HAL_GPIO_TEST, TOGGLE) {
   uint32_t expected_output = 0;
   PORT->Group[0].OUTTGL.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output |= 1 << i;
     ToggleGPIOPin(kGPIOPortA, i);
     EXPECT_EQ(PORT->Group[0].OUTTGL.reg, expected_output);
   }
 }
 
-TEST(HAL_GPIO_TEST, SAMPLE)
-{
+TEST(HAL_GPIO_TEST, SAMPLE) {
   uint32_t expected_output = 0;
   PORT->Group[0].OUTTGL.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output |= 1 << i;
     SetGPIOPinSamplingMode(kGPIOPortA, i, kGPIOSampleContinuously);
     EXPECT_EQ(PORT->Group[0].CTRL.reg, expected_output);
@@ -160,89 +142,52 @@ TEST(HAL_GPIO_TEST, SAMPLE)
   }
 }
 
-TEST(HAL_GPIO_TEST, GETDIR)
-{
+TEST(HAL_GPIO_TEST, GETDIR) {
   uint32_t expected_output = 0;
   PORT->Group[0].DIR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output = i % 2 ? 0 : 1;
     PORT->Group[0].DIR.reg |= i % 2 ? 0 : 1 << i;
     EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
   }
   PORT->Group[0].DIR.reg = 0;
   expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
   }
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output = i % 2 ? 1 : 0;
     PORT->Group[0].DIR.reg |= i % 2 ? 1 << i : 0;
     EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
   }
 }
 
-TEST(HAL_GPIO_TEST, GETLVL)
-{
+TEST(HAL_GPIO_TEST, GETLVL) {
   uint32_t expected_output = 0;
   PORT->Group[0].OUT.reg = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output = i % 2 ? 0 : 1;
     PORT->Group[0].OUT.reg |= i % 2 ? 0 : 1 << i;
     EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
   }
   PORT->Group[0].OUT.reg = 0;
   expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
   }
-  for (uint8_t i = 0; i < 32; i++)
-  {
+  for (uint8_t i = 0; i < 32; i++) {
     expected_output = i % 2 ? 1 : 0;
     PORT->Group[0].OUT.reg |= i % 2 ? 1 << i : 0;
     EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
   }
 }
 
-TEST(HAL_GPIO_TEST, GETDRVSTR)
-{
-  uint32_t expected_output = 0;
-  for(uint8_t i = 0; i< 32; i++) {
-    PORT->Group[0].PINCFG[i].reg = 0;
-  }
-  for (uint8_t i = 0; i < 32; i++)
-  {
-    expected_output = i % 2 ? 0 : 1;
-    PORT->Group[0].PINCFG[i].reg = i % 2 ? 0 : 1 << 22;
-    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
-  }
-  for(uint8_t i = 0; i< 32; i++) {
-    PORT->Group[0].PINCFG[i].reg = 0;
-  }
-  expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++)
-  {
-    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
-  }
-  for (uint8_t i = 0; i < 32; i++)
-  {
-    expected_output = i % 2 ? 1 : 0;
-    PORT->Group[0].PINCFG[i].reg |= i % 2 ? 1 << 22 : 0;
-    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
-  }
-}
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   // ::testing::InitGoogleTest(&argc, argv);
   // if you plan to use GMock, replace the line above with
   ::testing::InitGoogleMock(&argc, argv);
 
-  if (RUN_ALL_TESTS())
-  {
+  if (RUN_ALL_TESTS()) {
   }
 
   // Always return zero-code and allow PlatformIO to parse results

--- a/modules/hal_gpio/test/hal_gpio_unit_test.cc
+++ b/modules/hal_gpio/test/hal_gpio_unit_test.cc
@@ -35,60 +35,65 @@ using namespace hal::gpio;
 
 TEST(HAL_GPIO_TEST, DIRSET) {
   uint32_t expected_output = 0;
-  PORT->Group[0].DIRSET.reg = 0;
-  PORT->Group[0].DIRCLR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output |= 1 << i;
-    SetGPIOPinDirection(kGPIOPortA, i, kGPIODirOutput);
-    EXPECT_EQ(PORT->Group[0].DIRSET.reg, expected_output);
-    EXPECT_EQ(PORT->Group[0].DIRCLR.reg, 0);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].DIRSET.reg = 0;
+    PORT->Group[port_num].DIRCLR.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output |= 1 << pin_num;
+      SetGPIOPinDirection((GPIOPort) port_num, pin_num, kGPIODirOutput);
+      EXPECT_EQ(PORT->Group[port_num].DIRSET.reg, expected_output);
+      EXPECT_EQ(PORT->Group[port_num].DIRCLR.reg, 0);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, DIRCLR) {
   uint32_t expected_output = 0;
-  PORT->Group[0].DIRSET.reg = 0;
-  PORT->Group[0].DIRCLR.reg = 0;
-  const uint8_t regsize_in_bits = sizeof(PORT->Group[0].DIRCLR.reg) * 8;
-  for (uint8_t i = 0; i < regsize_in_bits; i++) {
-    expected_output |= 1 << i;
-    SetGPIOPinDirection(kGPIOPortA, i, kGPIODirInput);
-    EXPECT_EQ(PORT->Group[0].DIRCLR.reg, expected_output);
-    EXPECT_EQ(PORT->Group[0].DIRSET.reg, 0);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].DIRSET.reg = 0;
+    PORT->Group[port_num].DIRCLR.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output |= 1 << pin_num;
+      SetGPIOPinDirection((GPIOPort) port_num, pin_num, kGPIODirInput);
+      EXPECT_EQ(PORT->Group[port_num].DIRCLR.reg, expected_output);
+      EXPECT_EQ(PORT->Group[port_num].DIRSET.reg, 0);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, DRIVESTRENGTH) {
   uint32_t expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    PORT->Group[0].PINCFG[i].reg = 0;
-    expected_output = 0;
-    SetGPIOPinDriveStrength(kGPIOPortA, i, kGPIONormalDriveStrength);
-    EXPECT_EQ(PORT->Group[0].PINCFG[i].reg, expected_output);
-    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
-    expected_output = 1 << 6;
-    SetGPIOPinDriveStrength(kGPIOPortA, i, kGPIOStrongDriveStrength);
-    EXPECT_EQ(PORT->Group[0].PINCFG[i].reg, expected_output);
-    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), 1);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      PORT->Group[port_num].PINCFG[pin_num].reg = 0;
+      expected_output = 0;
+      SetGPIOPinDriveStrength((GPIOPort) port_num, pin_num, kGPIONormalDriveStrength);
+      EXPECT_EQ(PORT->Group[port_num].PINCFG[pin_num].reg, expected_output);
+      EXPECT_EQ(GetGPIODriveStrength((GPIOPort) port_num, pin_num), expected_output);
+      expected_output = 1 << 6;
+      SetGPIOPinDriveStrength((GPIOPort) port_num, pin_num, kGPIOStrongDriveStrength);
+      EXPECT_EQ(PORT->Group[port_num].PINCFG[pin_num].reg, expected_output);
+      EXPECT_EQ(GetGPIODriveStrength((GPIOPort) port_num, pin_num), 1);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, PINFUNCTION) {
   uint32_t output = 0;
-  for (uint8_t pin_group = 0; pin_group < PORT_GROUP_NUM; pin_group++) {
-    for (uint8_t pin_func = 0; pin_func < 4; pin_func++) {
-      for (uint8_t pin_num = 0; pin_num < 32; pin_num++) {
-        PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXO = 0;
-        PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXE = 0;
-        SetGPIOPinFunction((GPIOPort) pin_group, pin_num, (GPIOPinFunction) pin_func);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    for (uint8_t pin_func = 0; pin_func < kGPIOFunctionN; pin_func++) {
+      for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+        PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXO = 0;
+        PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXE = 0;
+        SetGPIOPinFunction((GPIOPort) port_num, pin_num, (GPIOPinFunction) pin_func);
         if (pin_num % 2) {
-          output = PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXO;
+          output = PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXO;
           EXPECT_EQ(output, pin_func);
-          EXPECT_EQ(GetGPIOPinFunction((GPIOPort) pin_group, pin_num), pin_func);
+          EXPECT_EQ(GetGPIOPinFunction((GPIOPort) port_num, pin_num), pin_func);
         } else {
-          output = PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXE;
+          output = PORT->Group[port_num].PMUX[pin_num >> 1].bit.PMUXE;
           EXPECT_EQ(output, pin_func);
-          EXPECT_EQ(GetGPIOPinFunction((GPIOPort) pin_group, pin_num), pin_func);
+          EXPECT_EQ(GetGPIOPinFunction((GPIOPort) port_num, pin_num), pin_func);
         }
       }
     }
@@ -97,88 +102,100 @@ TEST(HAL_GPIO_TEST, PINFUNCTION) {
 
 TEST(HAL_GPIO_TEST, OUTSET) {
   uint32_t expected_output = 0;
-  PORT->Group[0].OUTSET.reg = 0;
-  PORT->Group[0].OUTCLR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output |= 1 << i;
-    SetGPIOPinLevel(kGPIOPortA, i, 1);
-    EXPECT_EQ(PORT->Group[0].OUTSET.reg, expected_output);
-    EXPECT_EQ(PORT->Group[0].OUTCLR.reg, 0);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].OUTSET.reg = 0;
+    PORT->Group[port_num].OUTCLR.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output |= 1 << pin_num;
+      SetGPIOPinLevel((GPIOPort) port_num, pin_num, 1);
+      EXPECT_EQ(PORT->Group[port_num].OUTSET.reg, expected_output);
+      EXPECT_EQ(PORT->Group[port_num].OUTCLR.reg, 0);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, OUTCLR) {
   uint32_t expected_output = 0;
-  PORT->Group[0].OUTSET.reg = 0;
-  PORT->Group[0].OUTCLR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output |= 1 << i;
-    SetGPIOPinLevel(kGPIOPortA, i, 0);
-    EXPECT_EQ(PORT->Group[0].OUTCLR.reg, expected_output);
-    EXPECT_EQ(PORT->Group[0].OUTSET.reg, 0);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].OUTSET.reg = 0;
+    PORT->Group[port_num].OUTCLR.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output |= 1 << pin_num;
+      SetGPIOPinLevel((GPIOPort) port_num, pin_num, 0);
+      EXPECT_EQ(PORT->Group[port_num].OUTCLR.reg, expected_output);
+      EXPECT_EQ(PORT->Group[port_num].OUTSET.reg, 0);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, TOGGLE) {
   uint32_t expected_output = 0;
-  PORT->Group[0].OUTTGL.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output |= 1 << i;
-    ToggleGPIOPin(kGPIOPortA, i);
-    EXPECT_EQ(PORT->Group[0].OUTTGL.reg, expected_output);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].OUTTGL.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output |= 1 << pin_num;
+      ToggleGPIOPin((GPIOPort) port_num, pin_num);
+      EXPECT_EQ(PORT->Group[port_num].OUTTGL.reg, expected_output);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, SAMPLE) {
   uint32_t expected_output = 0;
-  PORT->Group[0].OUTTGL.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output |= 1 << i;
-    SetGPIOPinSamplingMode(kGPIOPortA, i, kGPIOSampleContinuously);
-    EXPECT_EQ(PORT->Group[0].CTRL.reg, expected_output);
-    expected_output &= ~(1 << i);
-    SetGPIOPinSamplingMode(kGPIOPortA, i, kGPIOSampleOnDemand);
-    EXPECT_EQ(PORT->Group[0].CTRL.reg, expected_output);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].OUTTGL.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output |= 1 << pin_num;
+      SetGPIOPinSamplingMode((GPIOPort) port_num, pin_num, kGPIOSampleContinuously);
+      EXPECT_EQ(PORT->Group[port_num].CTRL.reg, expected_output);
+      expected_output &= ~(1 << pin_num);
+      SetGPIOPinSamplingMode((GPIOPort) port_num, pin_num, kGPIOSampleOnDemand);
+      EXPECT_EQ(PORT->Group[port_num].CTRL.reg, expected_output);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, GETDIR) {
   uint32_t expected_output = 0;
-  PORT->Group[0].DIR.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output = i % 2 ? 0 : 1;
-    PORT->Group[0].DIR.reg |= i % 2 ? 0 : 1 << i;
-    EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
-  }
-  PORT->Group[0].DIR.reg = 0;
-  expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
-  }
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output = i % 2 ? 1 : 0;
-    PORT->Group[0].DIR.reg |= i % 2 ? 1 << i : 0;
-    EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].DIR.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output = pin_num % 2 ? 0 : 1;
+      PORT->Group[port_num].DIR.reg |= pin_num % 2 ? 0 : 1 << pin_num;
+      EXPECT_EQ(GetGPIOPinDirection((GPIOPort) port_num, pin_num), expected_output);
+    }
+    PORT->Group[port_num].DIR.reg = 0;
+    expected_output = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      EXPECT_EQ(GetGPIOPinDirection((GPIOPort) port_num, pin_num), expected_output);
+    }
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output = pin_num % 2 ? 1 : 0;
+      PORT->Group[port_num].DIR.reg |= pin_num % 2 ? 1 << pin_num : 0;
+      EXPECT_EQ(GetGPIOPinDirection((GPIOPort) port_num, pin_num), expected_output);
+    }
   }
 }
 
 TEST(HAL_GPIO_TEST, GETLVL) {
   uint32_t expected_output = 0;
-  PORT->Group[0].OUT.reg = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output = i % 2 ? 0 : 1;
-    PORT->Group[0].OUT.reg |= i % 2 ? 0 : 1 << i;
-    EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
-  }
-  PORT->Group[0].OUT.reg = 0;
-  expected_output = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
-  }
-  for (uint8_t i = 0; i < 32; i++) {
-    expected_output = i % 2 ? 1 : 0;
-    PORT->Group[0].OUT.reg |= i % 2 ? 1 << i : 0;
-    EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
+  for (uint8_t port_num = 0; port_num < PORT_GROUP_NUM; port_num++) {
+    PORT->Group[port_num].OUT.reg = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output = pin_num % 2 ? 0 : 1;
+      PORT->Group[port_num].OUT.reg |= pin_num % 2 ? 0 : 1 << pin_num;
+      EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, pin_num), expected_output);
+    }
+    PORT->Group[port_num].OUT.reg = 0;
+    expected_output = 0;
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, pin_num), expected_output);
+    }
+    for (uint8_t pin_num = 0; pin_num < PINS_PER_PORT; pin_num++) {
+      expected_output = pin_num % 2 ? 1 : 0;
+      PORT->Group[port_num].OUT.reg |= pin_num % 2 ? 1 << pin_num : 0;
+      EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, pin_num), expected_output);
+    }
   }
 }
 

--- a/modules/hal_gpio/test/hal_gpio_unit_test.cc
+++ b/modules/hal_gpio/test/hal_gpio_unit_test.cc
@@ -1,0 +1,250 @@
+/* *******************************************************************************************
+ * Copyright (c) 2023 by RobotPatient Simulators
+ *
+ * Authors: Richard Kroesen en Victor Hogeweij
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction,
+ *
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software
+ * is furnished to do so,
+ *
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ ***********************************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gpio.hpp>
+#include <sam.h>
+
+static Port MockPort;
+volatile Port *PORT = &MockPort;
+using namespace hal::gpio;
+
+TEST(HAL_GPIO_TEST, DIRSET)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].DIRSET.reg = 0;
+  PORT->Group[0].DIRCLR.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output |= 1 << i;
+    SetGPIOPinDirection(kGPIOPortA, i, kGPIODirOutput);
+    EXPECT_EQ(PORT->Group[0].DIRSET.reg, expected_output);
+    EXPECT_EQ(PORT->Group[0].DIRCLR.reg, 0);
+  }
+}
+
+TEST(HAL_GPIO_TEST, DIRCLR)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].DIRSET.reg = 0;
+  PORT->Group[0].DIRCLR.reg = 0;
+  const uint8_t regsize_in_bits = sizeof(PORT->Group[0].DIRCLR.reg) * 8;
+  for (uint8_t i = 0; i < regsize_in_bits; i++)
+  {
+    expected_output |= 1 << i;
+    SetGPIOPinDirection(kGPIOPortA, i, kGPIODirInput);
+    EXPECT_EQ(PORT->Group[0].DIRCLR.reg, expected_output);
+    EXPECT_EQ(PORT->Group[0].DIRSET.reg, 0);
+  }
+}
+
+TEST(HAL_GPIO_TEST, DRIVESTRENGTH)
+{
+  uint32_t expected_output = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    PORT->Group[0].PINCFG[i].reg = 0;
+    expected_output = 0;
+    SetGPIOPinDriveStrength(kGPIOPortA, i, kGPIONormalDriveStrength);
+    EXPECT_EQ(PORT->Group[0].PINCFG[i].reg, expected_output);
+    expected_output = 1 << 6;
+    SetGPIOPinDriveStrength(kGPIOPortA, i, kGPIOStrongDriveStrength);
+    EXPECT_EQ(PORT->Group[0].PINCFG[i].reg, expected_output);
+  }
+}
+
+TEST(HAL_GPIO_TEST, PINFUNCTION)
+{
+  uint32_t output = 0;
+  for (uint8_t pin_group = 0; pin_group < PORT_GROUP_NUM; pin_group++)
+  {
+    for (uint8_t pin_func = 0; pin_func < 4; pin_func++)
+    {
+      for (uint8_t pin_num = 0; pin_num < 32; pin_num++)
+      {
+        PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXO = 0;
+        PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXE = 0;
+        SetGPIOPinFunction((GPIOPort)pin_group, pin_num, (GPIOPinFunction)pin_func);
+        if (pin_num % 2)
+        {
+          output = PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXO;
+          EXPECT_EQ(output, pin_func);
+        }
+        else
+        {
+          output = PORT->Group[pin_group].PMUX[pin_num >> 1].bit.PMUXE;
+          EXPECT_EQ(output, pin_func);
+        }
+      }
+    }
+  }
+}
+
+TEST(HAL_GPIO_TEST, OUTSET)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].OUTSET.reg = 0;
+  PORT->Group[0].OUTCLR.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output |= 1 << i;
+    SetGPIOPinLevel(kGPIOPortA, i, 1);
+    EXPECT_EQ(PORT->Group[0].OUTSET.reg, expected_output);
+    EXPECT_EQ(PORT->Group[0].OUTCLR.reg, 0);
+  }
+}
+
+TEST(HAL_GPIO_TEST, OUTCLR)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].OUTSET.reg = 0;
+  PORT->Group[0].OUTCLR.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output |= 1 << i;
+    SetGPIOPinLevel(kGPIOPortA, i, 0);
+    EXPECT_EQ(PORT->Group[0].OUTCLR.reg, expected_output);
+    EXPECT_EQ(PORT->Group[0].OUTSET.reg, 0);
+  }
+}
+
+TEST(HAL_GPIO_TEST, TOGGLE)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].OUTTGL.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output |= 1 << i;
+    ToggleGPIOPin(kGPIOPortA, i);
+    EXPECT_EQ(PORT->Group[0].OUTTGL.reg, expected_output);
+  }
+}
+
+TEST(HAL_GPIO_TEST, SAMPLE)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].OUTTGL.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output |= 1 << i;
+    SetGPIOPinSamplingMode(kGPIOPortA, i, kGPIOSampleContinuously);
+    EXPECT_EQ(PORT->Group[0].CTRL.reg, expected_output);
+    expected_output &= ~(1 << i);
+    SetGPIOPinSamplingMode(kGPIOPortA, i, kGPIOSampleOnDemand);
+    EXPECT_EQ(PORT->Group[0].CTRL.reg, expected_output);
+  }
+}
+
+TEST(HAL_GPIO_TEST, GETDIR)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].DIR.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output = i % 2 ? 0 : 1;
+    PORT->Group[0].DIR.reg |= i % 2 ? 0 : 1 << i;
+    EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
+  }
+  PORT->Group[0].DIR.reg = 0;
+  expected_output = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
+  }
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output = i % 2 ? 1 : 0;
+    PORT->Group[0].DIR.reg |= i % 2 ? 1 << i : 0;
+    EXPECT_EQ(GetGPIOPinDirection(kGPIOPortA, i), expected_output);
+  }
+}
+
+TEST(HAL_GPIO_TEST, GETLVL)
+{
+  uint32_t expected_output = 0;
+  PORT->Group[0].OUT.reg = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output = i % 2 ? 0 : 1;
+    PORT->Group[0].OUT.reg |= i % 2 ? 0 : 1 << i;
+    EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
+  }
+  PORT->Group[0].OUT.reg = 0;
+  expected_output = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
+  }
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output = i % 2 ? 1 : 0;
+    PORT->Group[0].OUT.reg |= i % 2 ? 1 << i : 0;
+    EXPECT_EQ(GetGPIOPinLevel(kGPIOPortA, i), expected_output);
+  }
+}
+
+TEST(HAL_GPIO_TEST, GETDRVSTR)
+{
+  uint32_t expected_output = 0;
+  for(uint8_t i = 0; i< 32; i++) {
+    PORT->Group[0].PINCFG[i].reg = 0;
+  }
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output = i % 2 ? 0 : 1;
+    PORT->Group[0].PINCFG[i].reg = i % 2 ? 0 : 1 << 22;
+    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
+  }
+  for(uint8_t i = 0; i< 32; i++) {
+    PORT->Group[0].PINCFG[i].reg = 0;
+  }
+  expected_output = 0;
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
+  }
+  for (uint8_t i = 0; i < 32; i++)
+  {
+    expected_output = i % 2 ? 1 : 0;
+    PORT->Group[0].PINCFG[i].reg |= i % 2 ? 1 << 22 : 0;
+    EXPECT_EQ(GetGPIODriveStrength(kGPIOPortA, i), expected_output);
+  }
+}
+int main(int argc, char **argv)
+{
+  // ::testing::InitGoogleTest(&argc, argv);
+  // if you plan to use GMock, replace the line above with
+  ::testing::InitGoogleMock(&argc, argv);
+
+  if (RUN_ALL_TESTS())
+  {
+  }
+
+  // Always return zero-code and allow PlatformIO to parse results
+  return 0;
+}

--- a/modules/hal_gpio/test/mocks/sam.h
+++ b/modules/hal_gpio/test/mocks/sam.h
@@ -1,0 +1,142 @@
+#ifndef SAM_H
+#define SAM_H
+#include <stdint.h>
+
+#define PORT_GROUP_NUM 2
+
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+
+typedef union {
+  struct {
+    uint32_t DIR:32;           /*!< bit:  0..31  Port Data Direction                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIR_Type;
+
+typedef union {
+  struct {
+    uint32_t DIRCLR:32;        /*!< bit:  0..31  Port Data Direction Clear          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRCLR_Type;
+
+typedef union {
+  struct {
+    uint32_t DIRSET:32;        /*!< bit:  0..31  Port Data Direction Set            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRSET_Type;
+
+typedef union {
+  struct {
+    uint32_t DIRTGL:32;        /*!< bit:  0..31  Port Data Direction Toggle         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRTGL_Type;
+
+typedef union {
+  struct {
+    uint32_t OUT:32;           /*!< bit:  0..31  Port Data Output Value             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUT_Type;
+
+typedef union {
+  struct {
+    uint32_t OUTCLR:32;        /*!< bit:  0..31  Port Data Output Value Clear       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTCLR_Type;
+
+typedef union {
+  struct {
+    uint32_t OUTSET:32;        /*!< bit:  0..31  Port Data Output Value Set         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTSET_Type;
+
+typedef union {
+  struct {
+    uint32_t OUTTGL:32;        /*!< bit:  0..31  Port Data Output Value Toggle      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTTGL_Type;
+
+typedef union {
+  struct {
+    uint32_t IN:32;            /*!< bit:  0..31  Port Data Input Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_IN_Type;
+
+typedef union {
+  struct {
+    uint32_t SAMPLING:32;      /*!< bit:  0..31  Input Sampling Mode                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_CTRL_Type;
+
+typedef union {
+  struct {
+    uint32_t PINMASK:16;       /*!< bit:  0..15  Pin Mask for Multiple Pin Configuration */
+    uint32_t PMUXEN:1;         /*!< bit:     16  Peripheral Multiplexer Enable      */
+    uint32_t INEN:1;           /*!< bit:     17  Input Enable                       */
+    uint32_t PULLEN:1;         /*!< bit:     18  Pull Enable                        */
+    uint32_t :3;               /*!< bit: 19..21  Reserved                           */
+    uint32_t DRVSTR:1;         /*!< bit:     22  Output Driver Strength Selection   */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t PMUX:4;           /*!< bit: 24..27  Peripheral Multiplexing            */
+    uint32_t WRPMUX:1;         /*!< bit:     28  Write PMUX                         */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t WRPINCFG:1;       /*!< bit:     30  Write PINCFG                       */
+    uint32_t HWSEL:1;          /*!< bit:     31  Half-Word Select                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_WRCONFIG_Type;
+
+typedef union {
+  struct {
+    uint8_t  PMUXE:4;          /*!< bit:  0.. 3  Peripheral Multiplexing Even       */
+    uint8_t  PMUXO:4;          /*!< bit:  4.. 7  Peripheral Multiplexing Odd        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PMUX_Type;
+
+typedef union {
+  struct {
+    uint8_t  PMUXEN:1;         /*!< bit:      0  Peripheral Multiplexer Enable      */
+    uint8_t  INEN:1;           /*!< bit:      1  Input Enable                       */
+    uint8_t  PULLEN:1;         /*!< bit:      2  Pull Enable                        */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  DRVSTR:1;         /*!< bit:      6  Output Driver Strength Selection   */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PINCFG_Type;
+
+
+typedef struct {
+  volatile PORT_DIR_Type             DIR;         /**< \brief Offset: 0x00 (R/W 32) Data Direction */
+  volatile PORT_DIRCLR_Type          DIRCLR;      /**< \brief Offset: 0x04 (R/W 32) Data Direction Clear */
+  volatile PORT_DIRSET_Type          DIRSET;      /**< \brief Offset: 0x08 (R/W 32) Data Direction Set */
+  volatile PORT_DIRTGL_Type          DIRTGL;      /**< \brief Offset: 0x0C (R/W 32) Data Direction Toggle */
+  volatile PORT_OUT_Type             OUT;         /**< \brief Offset: 0x10 (R/W 32) Data Output Value */
+  volatile PORT_OUTCLR_Type          OUTCLR;      /**< \brief Offset: 0x14 (R/W 32) Data Output Value Clear */
+  volatile PORT_OUTSET_Type          OUTSET;      /**< \brief Offset: 0x18 (R/W 32) Data Output Value Set */
+  volatile PORT_OUTTGL_Type          OUTTGL;      /**< \brief Offset: 0x1C (R/W 32) Data Output Value Toggle */
+  volatile PORT_IN_Type              IN;          /**< \brief Offset: 0x20 (R/  32) Data Input Value */
+  volatile PORT_CTRL_Type            CTRL;        /**< \brief Offset: 0x24 (R/W 32) Control */
+  volatile PORT_WRCONFIG_Type        WRCONFIG;    /**< \brief Offset: 0x28 ( /W 32) Write Configuration */
+       RoReg8                    Reserved1[0x4];
+  volatile PORT_PMUX_Type            PMUX[16];    /**< \brief Offset: 0x30 (R/W  8) Peripheral Multiplexing n */
+  volatile PORT_PINCFG_Type          PINCFG[32];  /**< \brief Offset: 0x40 (R/W  8) Pin Configuration n */
+       RoReg8                    Reserved2[0x20];
+} PortGroup;
+
+typedef struct {
+       PortGroup                 Group[PORT_GROUP_NUM];    /**< \brief Offset: 0x00 PortGroup groups [GROUPS] */
+} Port;
+
+extern volatile Port* PORT;
+
+#endif

--- a/modules/hal_gpio/test/mocks/sam.h
+++ b/modules/hal_gpio/test/mocks/sam.h
@@ -1,3 +1,47 @@
+/**
+ * \file
+ *
+ *  Most of the code in this file is made by atmel but modfied to run on normal pc.
+ *
+ * \brief Component description for PORT
+ *
+ * Copyright (c) 2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
 #ifndef SAM_H
 #define SAM_H
 #include <stdint.h>

--- a/modules/hal_gpio/test/mocks/sam.h
+++ b/modules/hal_gpio/test/mocks/sam.h
@@ -46,7 +46,8 @@
 #define SAM_H
 #include <stdint.h>
 
-#define PORT_GROUP_NUM 2
+#define PINS_PER_PORT 32
+#define PORT_GROUP_NUM 1
 
 typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
 


### PR DESCRIPTION
What have I added:
- Unit tests using a hal mock  (almost straight copy from atmel asf with some small changes) which imitates the hardware regs.
- CMakelists to make it all compile..

What have I changed:
- GPIO.cpp had a wrong implementation for SetGPIOPinFunction. GPIOPins had to be shifted one to right. Because PMUX reg has one array index for two pin numbers... Look at the datasheet:  [SAMD21 section 23.8.12](https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-D21-DA1-Family-Data-Sheet-DS40001882H.pdf#page=385)
- CPPLINT everything

What should be improved:
These are functional unit tests meaning they only test the function. As is with most of the unit tests right now. It is also important to test the parameters (out of bounds and such..). But that is gonna be a lot easier when done with exception library. Which is still in progress.. therefore I only made functional tests..